### PR TITLE
Update which forums we refer people to.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,10 @@
 # How to contribute to the WWT Web Site
 
-Currently, there are two ways to make an edit to the website. 
+Please see http://worldwidetelescope.org/Learn/WebDevelopment#addnewpage for detailed instructions.
+
+In general, there are two ways to make an edit to the website:
+
 * On a Windows machine, install Visual Studio Community Edition (see README for WorldWideTelescope/wwt-windows-client) and then make sure you have IIS installed.  Then when you make a local change you can see the result locally to make sure it is what you want (and before you submit a pull request).
 * If you aren't on a Windows machine, you can edit the approprite file with a text editor.  Then when you submit a pull request, indicate in the request the intention of your edit and then say that you have not tested this in a test web environment and ask the committer to test things out for you first.
+
+Note that there is a master template page that is used for (almost) all pages but *not* for the home page: `WWTMVC5/Views/Shared/_ContentPage.cshtml`

--- a/WWTMVC5/Views/Support/IssuesAndBugs.cshtml
+++ b/WWTMVC5/Views/Support/IssuesAndBugs.cshtml
@@ -9,130 +9,22 @@
 <script src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-validator/0.4.5/js/bootstrapvalidator.min.js"></script>
 <h1>Issues, Bugs and Support for WorldWide Telescope</h1> 
 
+	<p>Support for WorldWide Telescope is provided through our discussion forums <a class="reg" href="http://forums.worldwidetelescope.org/" >forums.worldwidetelescope.org</a>.  To get troubleshooting help, ask general questions, or make suggestions, please post there.</p>
 
-	<p>Support for WorldWide Telescope is provided through our support forum <a class="reg" href="http://social.microsoft.com/Forums/en-US/worldwidetelescope">http://social.microsoft.com/Forums/en-US/worldwidetelescope</a>.<br><br> To find troubleshooting help please visit the WWT forum. To submit a suggestion via this page, provide your contact name and e-mail address (optional) in case we need to send you a response. Links to solutions for specific issues: </p>
-	<p>If you are having trouble installing or running the Windows® client version of WorldWide Telescope, you can use the WorldWide Telescope Web Client. The WorldWide Telescope Web Client beta version, which has a subset of the features in the full Windows version, but doesn’t require an application install and may run on systems that don't meet the system requirements for the Windows Client.</p>
-	<p>Because of the high volume we can't answer all e-mail personally. Please check the forums above to get the fastest asnwers to your questions.
-	So that we may better assist you, provide as many details as possible about the problem (all fields required) </p>
-	<form id="report">
+        <p>To report a bug, please file a ticket in the appropriate GitHub issue tracker:</p>
+        <p><ul><li><a class="reg" href="https://github.com/WorldWideTelescope/wwt-windows-client" >Windows client issue tracker</a></li>
+           <li><a class="reg" href="https://github.com/WorldWideTelescope/wwt-web-client" >Web Client issue tracker</a></li>
+           <li><a class="reg" href="https://github.com/WorldWideTelescope/wwt-website" >Web Site issue tracker</a></li>
+           <li><a class="reg" href="https://github.com/WorldWideTelescope/wwt-remote" >WWT Remote Cluster Controller issue tracker</a></li>
+           <li><a class="reg" href="https://github.com/WorldWideTelescope/" >(browse all WWT repositories/trackers)</a></li>
+           </ul></p>
 
-		<h3>Issue Form</h3>
-		<div class="form-group row">
-			<div class="col-md-8">
-				<label for="fullName" class="control-label">Full Name</label>
-				<div class="rel fa0">
-					<input type="text" placeholder="Full Name" class="form-control" name="fullName" />
-				</div>
-			</div>
-			
-		</div>
-		<div class="form-group row">
-			<div class="col-md-8">
-				<label for="email" class="control-label">Email Address</label>
-				<div class="rel fa0">
-					<input type="text" placeholder="Email Address" class="form-control" name="email" />
-				</div>
-			</div>
-		</div> 
-		<div class="form-group row">
-			<div class="col-md-8">
-				<label for="issueType" class="control-label">Issue Type</label>
-				<div class="rel">
-					<select name="issueType" class="form-control">
-						<option value="">[select]</option>
-						<option value="GeneralComment">General Comment</option>
-						<option value="Suggestion">Suggestion</option>
-						<option value="WindowsClientBug">Windows Client Bug</option>
-						<option value="WebClientBugPC">Web Client Bug - PC</option>
-						<option value="WebClientBugMac">Web Client Bug - Mac</option>
-					</select>
-				</div>
-			</div>
-		</div>
-		<div class="form-group row">
-			<div class="col-md-8">
-				<label for="comments" class="control-label">Comments</label>
-				<div class="rel fa0">
-					<textarea placeholder="Describe your issue in detail" class="form-control" name="comments"></textarea>
-				</div>
-				<div>(Be specific when describing the issue. The details that you include enable us to quickly identify the problem and its solution. Include your platform, operating system, browser and hardware you have such as processor, RAM and graphics card.)</div>
-			</div>
-		</div> 
-		<div class="form-group row">
-			<div class="col-md-8">
-				<button type="submit" class="btn btn-primary pull-right" id="btnSend">Send</button>
-			</div>
-		</div>
-	</form>
-	
-	
-	
-	
-	
-	<div id="confirmation" class="hide">
+        <p>When filing a bug report, please be as specific as possible.  The details that you include enable us to quickly identify the problem and its solution.  Tell us your platform, operating system, browser and hardware you have such as processor, RAM and graphics card.)</p>
 
-		<p>An issue report has been filed.</p>
-		<p>Thank you for sending your feedback.</p>
+	<p>If you're having trouble installing or running the <a class="reg" href="https://github.com/WorldWideTelescope/wwt-windows-client/" >Windows® client</a> version of WorldWide Telescope, you can use the WorldWide Telescope <a class="reg" href="https://github.com/WorldWideTelescope/wwt-web-client/" >Web Client</a> instead. The Web Client Beta version has a subset of the features in the full Windows version, but doesn't require an application install and may run on systems that don't meet the system requirements for the Windows Client.</p>
 
-	</div>
-<script>
-	$(function () {
+        <p>To contribute code (bug fixes, new features, etc) or documentation improvements, just use the standard GitHub <a class="reg" href="https://help.github.com/articles/using-pull-requests/" >"Pull Request"</a> method.  The PR will show up as an issue in the appropriate tracker, and we'll respond or ask further questions there.</p>
 
-		var reqField = function (msg) {
-			return {
-				validators: {
-					notEmpty: {
-						message: msg
-					}
-				}
-			}
-		}
-
-		$(window).on('initIssueForm', function () {
-			$('#report').bootstrapValidator({
-				excluded: ['specifics'],
-				fields: {
-					fullName: reqField('Please tell us your full name'),
-					email: {
-						validators: {
-							emailAddress: {
-								message: 'Enter a valid email address'
-							},
-							notEmpty:{message:'Please enter your email address'}
-						}
-					},
-					issueType: reqField('Select an issue type'),
-					comments: reqField('Please describe the issue')
-				},
-				//live: 'enabled',
-				message: 'invalid value',
-				submitButtons: '#btnSend',
-				submitHandler: function (validator, form) {
-					var data = {};
-					form.find('*[name]').each(function () {
-						data[$(this).attr('name')] = $(this).val();
-						//console.log($(this).attr('name'));
-					});
-					$.ajax({
-						url: '/Ashx/IssuesAndBugs.ashx',
-						data: data,
-						success: function (response, status, xhr) {
-							if (xhr.status == 200) {
-								$('#confirmation').removeClass('hide');
-								form.remove();
-								wwt.triggerResize();
-							}
-						}
-					});
-					return false;
-				},
-				trigger: null
-			});
-		});
-		$(window).trigger('initIssueForm');
-
-	});
-</script>
 <style>
 	.has-feedback i.fa {
 		top: 0;


### PR DESCRIPTION
* WWTMVC5/Views/Support/IssuesAndBugs.cshtml: Link to the new
  Discourse forums now, instead of the old Microsoft Social forums.
  Get rid of the embedded form, because as far as I know we don't
  have support for it in the new Discourse universe.

* CONTRIBUTING.md: Link to the new online instructions for editing the
  web site, as a pre-emptive measure to avoid lots of questions in the
  forums about how to edit the web site.

NOTE: This change has not been tested, because I didn't have the Visual Studio setup.  Please check not just its content but its syntactic correctness as well, before merging to master.