### PR TITLE
WWTMVC5/Views/Learn/SettingUp.cshtml: fix link to MIDI controller file

### DIFF
--- a/WWTMVC5/Views/Learn/SettingUp.cshtml
+++ b/WWTMVC5/Views/Learn/SettingUp.cshtml
@@ -81,7 +81,7 @@
 				<div class="panel-body">
 					<p>Currently, WorldWide Telescope (WWT) can be controlled by a variety of controllers.  Custom mapping can be done for MIDI and Xbox controllers, connected by USB to the computer running WWT as well as configurable virtual buttons.</p>
 					<h4>MIDI Controller</h4>
-					<p>Any MIDI controller can be used to control WorldWide Telescope.  You can re-use mapping of WWT functions created by someone else.  You can also create your own or edit a previously-created mapping.  Start by selecting “Settings/Controller Setup...”  This brings up a dialog window where you can select a file containing the mapping functions.  For the Numark DJ2Go you can <a href="@Model.ResLoc/Content/Learn/Numark%20DJ2Go.wwtmm">download a standard mapping file</a>.</p>
+					<p>Any MIDI controller can be used to control WorldWide Telescope.  You can re-use mapping of WWT functions created by someone else.  You can also create your own or edit a previously-created mapping.  Start by selecting “Settings/Controller Setup...”  This brings up a dialog window where you can select a file containing the mapping functions.  For the Numark DJ2Go you can <a href="@Model.ContentDir/learn/Numark%20DJ2Go.wwtmm">download a standard mapping file</a>.</p>
 					<img src="@Model.ImgDir/learn/numark_djtogo.jpg" alt="Numark DJ2Go" class="img-responsive img-border" />
 					<p>You can save and load different files with different mappings.</p>
 					<p>Highlighting a device in the list of MIDI devices on the left and clicking “Properties” below will bring up the Controller Properties window that presents the status of the controller and location to the image file used for mapping.  Note, that this image can be specified as a URL, such as</p>


### PR DESCRIPTION
Closes #57.

It looks like there are other links in the web tree of the form `@Model.ResLoc/Content/...` that *are* correct, so the change I'm doing here doesn't seem to (need to) be applied globally.