### PR TITLE
Do not use assembly resources for thumbnails

### DIFF
--- a/WWTMVC5/WWTWeb/thumbnail.aspx
+++ b/WWTMVC5/WWTWeb/thumbnail.aspx
@@ -1,4 +1,5 @@
 <%@ Page Language="C#" ContentType="image/jpeg" %>
+
 <%@ Import Namespace="System.Drawing" %>
 <%@ Import Namespace="System.Drawing.Text" %>
 <%@ Import Namespace="System.Drawing.Imaging" %>
@@ -11,32 +12,10 @@
     string name = Request.Params["name"];
     string type = Request.Params["class"];
 
-    Stream s = WWTThumbnail.GetThumbnailStream(name);
-    if (s == null && type != null)
+    using (var s = WWTThumbnail.GetThumbnailStream(name, type))
     {
-        s = WWTThumbnail.GetThumbnailStream(type);
+        s.CopyTo(Response.OutputStream);
+        Response.Flush();
+        Response.End();
     }
-
-    if (s == null)
-    {
-        string dataDir = ConfigurationManager.AppSettings["DataDir"];
-
-        var jpeg = Path.Combine(dataDir, "thumbnails", name + ".jpg");
-        if (File.Exists(jpeg))
-        {
-            Response.WriteFile(jpeg);
-            Response.End();
-        }
-
-        s = File.OpenRead(Path.Combine(dataDir, "thumbnails", "Star.jpg"));
-    }
-
-    int length = (int)s.Length;
-    byte[] data = new byte[length];
-    s.Read(data, 0, length);
-    Response.OutputStream.Write(data, 0, length);
-    Response.Flush();
-    Response.End();
-    s.Dispose();
-
-	%>
+%>

--- a/WWTWebservices/WWTThumbnail.cs
+++ b/WWTWebservices/WWTThumbnail.cs
@@ -1,28 +1,33 @@
-﻿using System.Drawing;
+﻿using System.Configuration;
 using System.IO;
-using System.Reflection;
 
 namespace WWTThumbnails
 {
-	public class WWTThumbnail
-	{
-		public static Bitmap GetThumbnail(string fileName)
-		{
-			fileName = "WWTThumbnails.thumbnails." + fileName.ToLower() + ".jpg";
-			using (Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(fileName))
-			{
-				if (stream == null)
-				{
-					return null;
-				}
-				return new Bitmap(stream);
-			}
-		}
+    public class WWTThumbnail
+    {
+        private const string DefaultThumbnail = "Star";
 
-		public static Stream GetThumbnailStream(string fileName)
-		{
-			fileName = "WWTThumbnails.thumbnails." + fileName.ToLower() + ".jpg";
-			return Assembly.GetExecutingAssembly().GetManifestResourceStream(fileName);
-		}
-	}
+        public static Stream GetThumbnailStream(string name, string type)
+        {
+            return GetThumbnailStream(name) ?? GetThumbnailStream(type) ?? GetThumbnailStream(DefaultThumbnail);
+        }
+
+        private static Stream GetThumbnailStream(string fileName)
+        {
+            if (fileName is null)
+            {
+                return null;
+            }
+
+            var dataDir = ConfigurationManager.AppSettings["DataDir"];
+            var jpeg = Path.Combine(dataDir, "thumbnails", fileName + ".jpg");
+
+            if (!File.Exists(jpeg))
+            {
+                return File.OpenRead(jpeg);
+            }
+
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
This removes the searching for assembly resources that
WWTThumbnail.GetThunbnailStream(...) would use and instead just grab
them from disk. The previous thumbnails that were resource streams will
be moved to a data storage for the service.