### PR TITLE
Prefer thumbnails from assembly vs VM backup

### DIFF
--- a/WWTWebservices/WWTThumbnail.cs
+++ b/WWTWebservices/WWTThumbnail.cs
@@ -13,14 +13,16 @@ namespace WWTThumbnails
         }
 
         private static Stream GetThumbnailStream(string fileName)
+            => GetThumbnailStreamFromFile(fileName, "fromAssembly") ?? GetThumbnailStreamFromFile(fileName, "fromBackup");
+
+        private static Stream GetThumbnailStreamFromFile(string fileName, string sub)
         {
             if (fileName is null)
             {
                 return null;
             }
 
-            var dataDir = ConfigurationManager.AppSettings["DataDir"];
-            var jpeg = Path.Combine(dataDir, "thumbnails", fileName + ".jpg");
+            var jpeg = Path.Combine(ConfigurationManager.AppSettings["DataDir"], "thumbnails", sub, fileName + ".jpg");
 
             if (!File.Exists(jpeg))
             {


### PR DESCRIPTION
There are duplicate thumbnails from the VM backup and the assembly. For now, we can get the same behavior by placing the thumbnails in separate directories and preferring the ones from the assembly first.