### PR TITLE
Add initial RequestProvider infrastructure

### DIFF
--- a/WWTMVC5/WWTMVC5.csproj
+++ b/WWTMVC5/WWTMVC5.csproj
@@ -1449,6 +1449,10 @@
     <WCFMetadata Include="Service References\" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\src\WWT.Providers\WWT.Providers.csproj">
+      <Project>{ee4a3106-572b-4ef4-9ab5-a22643309a57}</Project>
+      <Name>WWT.Providers</Name>
+    </ProjectReference>
     <ProjectReference Include="..\WWTWebservices\WWTWebservices.csproj">
       <Project>{1cf4d986-51ad-43f8-a84a-38b6ecba2172}</Project>
       <Name>WWTWebservices</Name>

--- a/WWTMVC5/WWTWeb/2MASSOct.aspx
+++ b/WWTMVC5/WWTWeb/2MASSOct.aspx
@@ -1,27 +1,5 @@
 <%@ Page Language="C#" ContentType="image/png" %>
-<%@ Import Namespace="System.IO" %>
-<%@ Import Namespace="WWTWebservices" %>
+<%@ Import Namespace="WWT.Providers" %>
 <%
-    string query = Request.Params["Q"];
-    string[] values = query.Split(',');   
-    int level = Convert.ToInt32(values[0]);
-    int tileX = Convert.ToInt32(values[1]);
-    int tileY = Convert.ToInt32(values[2]);
-    string file = "2massoctset";
-	
-	string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
-
-	
-    if (level < 8)
-    {
-        Response.ContentType = "image/png";
-        Stream s = PlateTilePyramid.GetFileStream(String.Format(wwtTilesDir  + "\\{0}.plate",file), level, tileX, tileY);
-        int length = (int)s.Length;
-        byte[] data = new byte[length];
-        s.Read(data, 0, length);
-        Response.OutputStream.Write(data, 0, length);
-        Response.Flush();
-        Response.End();
-        return;
-    }
+    RequestProvider.Get<TwoMASSOctProvider>().Run(Request, Response);
 %>

--- a/WWTMVC5/Web.config
+++ b/WWTMVC5/Web.config
@@ -40,6 +40,7 @@
     <compilation debug="true" defaultLanguage="c#" targetFramework="4.8">
       <assemblies>
         <add assembly="WWTWebservices" />
+        <add assembly="WWT.Providers" />
         <add assembly="WWT.Imaging" />
         <add assembly="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51"/>
         <add assembly="System.IdentityModel.Services"/>

--- a/WWTWebSiteOnly.sln
+++ b/WWTWebSiteOnly.sln
@@ -5,41 +5,28 @@ VisualStudioVersion = 16.0.30309.148
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WWTMVC5", "WWTMVC5\WWTMVC5.csproj", "{53EB6FD6-9D50-45D4-9987-328A7AE53E2C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WWTWebservices", "WWTWebservices\WWTWebservices.csproj", "{1CF4D986-51AD-43F8-A84A-38B6ECBA2172}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WWTWebservices", "WWTWebservices\WWTWebservices.csproj", "{1CF4D986-51AD-43F8-A84A-38B6ECBA2172}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WWT.Providers", "src\WWT.Providers\WWT.Providers.csproj", "{EE4A3106-572B-4EF4-9AB5-A22643309A57}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|Mixed Platforms = Debug|Mixed Platforms
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-		Release|Mixed Platforms = Release|Mixed Platforms
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{53EB6FD6-9D50-45D4-9987-328A7AE53E2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{53EB6FD6-9D50-45D4-9987-328A7AE53E2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{53EB6FD6-9D50-45D4-9987-328A7AE53E2C}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{53EB6FD6-9D50-45D4-9987-328A7AE53E2C}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{53EB6FD6-9D50-45D4-9987-328A7AE53E2C}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{53EB6FD6-9D50-45D4-9987-328A7AE53E2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{53EB6FD6-9D50-45D4-9987-328A7AE53E2C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{53EB6FD6-9D50-45D4-9987-328A7AE53E2C}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{53EB6FD6-9D50-45D4-9987-328A7AE53E2C}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{53EB6FD6-9D50-45D4-9987-328A7AE53E2C}.Release|Mixed Platforms.Deploy.0 = Release|Any CPU
-		{53EB6FD6-9D50-45D4-9987-328A7AE53E2C}.Release|x86.ActiveCfg = Release|Any CPU
 		{1CF4D986-51AD-43F8-A84A-38B6ECBA2172}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1CF4D986-51AD-43F8-A84A-38B6ECBA2172}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1CF4D986-51AD-43F8-A84A-38B6ECBA2172}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{1CF4D986-51AD-43F8-A84A-38B6ECBA2172}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{1CF4D986-51AD-43F8-A84A-38B6ECBA2172}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{1CF4D986-51AD-43F8-A84A-38B6ECBA2172}.Debug|x86.Build.0 = Debug|Any CPU
 		{1CF4D986-51AD-43F8-A84A-38B6ECBA2172}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1CF4D986-51AD-43F8-A84A-38B6ECBA2172}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1CF4D986-51AD-43F8-A84A-38B6ECBA2172}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{1CF4D986-51AD-43F8-A84A-38B6ECBA2172}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{1CF4D986-51AD-43F8-A84A-38B6ECBA2172}.Release|x86.ActiveCfg = Release|Any CPU
-		{1CF4D986-51AD-43F8-A84A-38B6ECBA2172}.Release|x86.Build.0 = Release|Any CPU
+		{EE4A3106-572B-4EF4-9AB5-A22643309A57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE4A3106-572B-4EF4-9AB5-A22643309A57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE4A3106-572B-4EF4-9AB5-A22643309A57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE4A3106-572B-4EF4-9AB5-A22643309A57}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/WWT.Providers/RequestProvider.cs
+++ b/src/WWT.Providers/RequestProvider.cs
@@ -1,0 +1,17 @@
+﻿using System.Dynamic;
+using System.Web;
+
+namespace WWT.Providers
+{
+    public abstract class RequestProvider
+    {
+        public void Run(HttpRequest request, HttpResponse response)
+            => Run(new WwtContext(request, response));
+
+        public abstract void Run(WwtContext context);
+
+        public static RequestProvider Get<TProvider>()
+            where TProvider : RequestProvider, new()
+            => new TProvider();
+    }
+}

--- a/src/WWT.Providers/TwoMASSOctProvider.cs
+++ b/src/WWT.Providers/TwoMASSOctProvider.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Configuration;
+using System.IO;
+using WWTWebservices;
+
+namespace WWT.Providers
+{
+    public class TwoMASSOctProvider : RequestProvider
+    {
+        public override void Run(WwtContext context)
+        {
+            string query = context.Request.Params["Q"];
+            string[] values = query.Split(',');
+            int level = Convert.ToInt32(values[0]);
+            int tileX = Convert.ToInt32(values[1]);
+            int tileY = Convert.ToInt32(values[2]);
+            string file = "2massoctset";
+
+            string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
+
+            if (level < 8)
+            {
+                context.Response.ContentType = "image/png";
+                Stream s = PlateTilePyramid.GetFileStream(String.Format(wwtTilesDir + "\\{0}.plate", file), level, tileX, tileY);
+                int length = (int)s.Length;
+                byte[] data = new byte[length];
+                s.Read(data, 0, length);
+                context.Response.OutputStream.Write(data, 0, length);
+                context.Response.Flush();
+                context.Response.End();
+                return;
+            }
+        }
+    }
+}

--- a/src/WWT.Providers/WWT.Providers.csproj
+++ b/src/WWT.Providers/WWT.Providers.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\WWTWebservices\WWTWebservices.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web" />
+  </ItemGroup>
+
+</Project>

--- a/src/WWT.Providers/WwtContext.cs
+++ b/src/WWT.Providers/WwtContext.cs
@@ -1,0 +1,17 @@
+﻿using System.Web;
+
+namespace WWT.Providers
+{
+    public readonly struct WwtContext
+    {
+        public WwtContext(HttpRequest request, HttpResponse response)
+        {
+            Request = request;
+            Response = response;
+        }
+
+        public HttpRequest Request { get; }
+
+        public HttpResponse Response { get; }
+    }
+}


### PR DESCRIPTION
This will allow us to move code out from the code behind. Once that is done, we can more easily refactor things like file access so we can replace it with Azure access. This PR puts in the basics to enable this kind of workflow while showing an example for the 2MASSOct.aspx endpoint.

The goal is for the aspx pages to essentially contain nothing besides:

```csharp
RequestProvider.Get<Name>().Run(Request, Response)
```

Code is aspx and aspx.cs files are much more difficult to manage as they are compiled in a separate step from the main application. By moving them out, they will be compiled as normal. Tooling to help with refactoring and analysis can more easily work as-is. Especially since aspx/aspx.cs are fairly old at this point, new tooling doesn't really work with it.

The providers are currently just manually new'd up, but can be replaced with a DI (or for now probably ServiceLocator) pattern once that's in. The base class wraps the request and response objects in a context so derived types aren't depending on System.Web (they are indirectly for now, but this helps make it easier to redirect stuff in the future).