### PR TITLE
Replace string.GetHashCode() usage with IFileNameHasher

### DIFF
--- a/WWTMVC5/App_Start/UnityConfig.cs
+++ b/WWTMVC5/App_Start/UnityConfig.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using Microsoft.Practices.Unity;
 using WWT.Providers;
+using WWTWebservices;
 
 namespace WWTMVC5
 {
@@ -40,6 +41,7 @@ namespace WWTMVC5
 
             // TODO: Register your types here
             // container.RegisterType<IProductRepository, ProductRepository>();
+            container.RegisterType<IFileNameHasher, Net4x32BitFileNameHasher>(new ContainerControlledLifetimeManager());
         }
 
         private static void RegisterRequestProviders(IUnityContainer container)

--- a/WWTMVC5/GetTourFile.aspx
+++ b/WWTMVC5/GetTourFile.aspx
@@ -1,46 +1,6 @@
-<%@ Page Language="C#" ContentType="image/png" %>
-<%@ Import Namespace="System.IO" %>
-<%@ Import Namespace="System.Net" %>
-<%@ Import Namespace="WWTWebservices" %>
+<%@ Page Language="C#" ContentType="image/png" %> 
+
+<%@ Import Namespace="WWT.Providers" %>
 <%
-    string returnString = "Erorr: No URL Specified";
-    string url = "";
-    
-    string path = Server.MapPath(@"TourCache");
-
-    try
-    {
-        if (Request.Params["targeturl"] != null && Request.Params["filename"] != null)
-        {
-            url = Request.Params["targeturl"];
-
-            string targetfile = Request.Params["filename"];
-            string filename = path + "\\" + Math.Abs(url.GetHashCode()) + ".wtt";
-
-            if (!File.Exists(filename))
-            {
-                if (url.ToLower().StartsWith("http"))
-                {
-                    using (WebClient wc = new WebClient())
-                    {
-                        byte[] data = wc.DownloadData(url);
-
-                        //Response.ContentType = wc.ResponseHeaders["Content-type"].ToString();
-                        int length = data.Length;
-
-                        File.WriteAllBytes(filename, data);
-                        //Response.OutputStream.Write(data, 0, length);
-                    }
-                }
-            }
-
-
-            FileCabinet.Extract(filename, targetfile, Response);
-        }
-    }
-    catch (System.Exception e)
-    {
-        returnString = e.Message;
-        Response.Write(returnString);
-    }
+	RequestProvider.Get<GetTourFileProvider>().Run(this);
 %>

--- a/WWTMVC5/GetTourFile2.aspx
+++ b/WWTMVC5/GetTourFile2.aspx
@@ -1,47 +1,6 @@
-<%@ Page Language="C#" ContentType="image/png" %>
+<%@ Page Language="C#" ContentType="image/png" %> 
 
-<%@ Import Namespace="System.IO" %>
-<%@ Import Namespace="System.Net" %>
-<%@ Import Namespace="WWTWebservices" %>
+<%@ Import Namespace="WWT.Providers" %>
 <%
-    string returnString = "Error: No URL Specified";
-    string url = "";
-    
-    string path = Server.MapPath(@"TourCache");
-
-    try
-    {
-        if (Request.Params["targeturl"] != null && Request.Params["filename"] != null)
-        {
-            url = Request.Params["targeturl"];
-
-            string targetfile = Request.Params["filename"];
-            string filename = path + "\\" + Math.Abs(url.GetHashCode()) + ".wtt";
-
-            if (!File.Exists(filename))
-            {
-                if (url.ToLower().StartsWith("http"))
-                {
-                    using (WebClient wc = new WebClient())
-                    {
-                        byte[] data = wc.DownloadData(url);
-
-                        //Response.ContentType = wc.ResponseHeaders["Content-type"].ToString();
-                        int length = data.Length;
-
-                        File.WriteAllBytes(filename, data);
-                        //Response.OutputStream.Write(data, 0, length);
-                    }
-                }
-            }
-
-
-            FileCabinet.Extract(filename, targetfile, Response);
-        }
-    }
-    catch (System.Exception e)
-    {
-        returnString = e.Message;
-        Response.Write(returnString);
-    }
+	RequestProvider.Get<GetTourFileProvider>().Run(this);
 %>

--- a/WWTWebservices/IFileNameHasher.cs
+++ b/WWTWebservices/IFileNameHasher.cs
@@ -1,0 +1,7 @@
+﻿namespace WWTWebservices
+{
+    public interface IFileNameHasher
+    {
+        int HashName(string s);
+    }
+}

--- a/WWTWebservices/Net4x32BitFileNameHasher.cs
+++ b/WWTWebservices/Net4x32BitFileNameHasher.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace WWTWebservices
+{
+    public class Net4x32BitFileNameHasher : IFileNameHasher
+    {
+        /// <summary>
+        /// Implementation to mimix string.GetHashCode() of 32-bit .NET 4.x. Was used originally for hashing to get id
+        /// </summary>
+        /// <param name="s">Input string</param>
+        /// <returns>Stable hash</returns>
+        public int HashName(string s)
+            => Math.Abs(GetHashCode32BitNet4x(s));
+
+        private static unsafe int GetHashCode32BitNet4x(string s)
+        {
+            fixed (char* str = s.ToCharArray())
+            {
+                char* chPtr = str;
+                int num = 0x15051505;
+                int num2 = num;
+                int* numPtr = (int*)chPtr;
+
+                for (int i = s.Length; i > 0; i -= 4)
+                {
+                    num = (((num << 5) + num) + (num >> 0x1b)) ^ numPtr[0];
+                    if (i <= 2)
+                    {
+                        break;
+                    }
+                    num2 = (((num2 << 5) + num2) + (num2 >> 0x1b)) ^ numPtr[1];
+                    numPtr += 2;
+                }
+
+                return (num + (num2 * 0x5d588b65));
+            }
+        }
+    }
+}

--- a/WWTWebservices/WWTUtil.cs
+++ b/WWTWebservices/WWTUtil.cs
@@ -8,7 +8,6 @@ namespace WWTWebservices
 {
 
 
-
     public class WWTUtil
     {
         public WWTUtil()

--- a/src/WWT.Providers/Providers/GetTourFileProvider.cs
+++ b/src/WWT.Providers/Providers/GetTourFileProvider.cs
@@ -7,21 +7,24 @@ namespace WWT.Providers
 {
     public class GetTourFileProvider : RequestProvider
     {
+        private readonly IFileNameHasher _hasher;
+
+        public GetTourFileProvider(IFileNameHasher hasher)
+        {
+            _hasher = hasher;
+        }
+
         public override void Run(WwtContext context)
         {
-            string returnString = "Error: No URL Specified";
-            string url = "";
-
             string path = context.Server.MapPath(@"TourCache");
 
             try
             {
                 if (context.Request.Params["targeturl"] != null && context.Request.Params["filename"] != null)
                 {
-                    url = context.Request.Params["targeturl"];
-
+                    var url = context.Request.Params["targeturl"];
                     string targetfile = context.Request.Params["filename"];
-                    string filename = path + "\\" + Math.Abs(url.GetHashCode()) + ".wtt";
+                    string filename = Path.Combine(path, $"{_hasher.HashName(url)}.wtt");
 
                     if (!File.Exists(filename))
                     {
@@ -44,10 +47,9 @@ namespace WWT.Providers
                     FileCabinet.Extract(filename, targetfile, context.Response);
                 }
             }
-            catch (System.Exception e)
+            catch (Exception e)
             {
-                returnString = e.Message;
-                context.Response.Write(returnString);
+                context.Response.Write(e.Message);
             }
         }
     }

--- a/src/WWT.Providers/Providers/TileImageProvider.cs
+++ b/src/WWT.Providers/Providers/TileImageProvider.cs
@@ -8,6 +8,13 @@ namespace WWT.Providers
 {
     public class TileImageProvider : TileImage
     {
+        private readonly IFileNameHasher _hasher;
+
+        public TileImageProvider(IFileNameHasher hasher)
+        {
+            _hasher = hasher;
+        }
+
         public override void Run(WwtContext context)
         {
             {
@@ -53,7 +60,7 @@ namespace WWT.Providers
                     url = "http://www.spitzer.caltech.edu/uploaded_files/images/0009/0848/sig12-011.jpg";
                 }
 
-                int hashID = Math.Abs(url.GetHashCode());
+                int hashID = _hasher.HashName(url);
 
                 //hashID = 12345;
                 string path = WWTUtil.GetCurrentConfigShare("DSSTileCache", true) + "\\imagesTiler\\dowloadImages\\";

--- a/src/WWT.Providers/Providers/WMSEarthTodayProvider.cs
+++ b/src/WWT.Providers/Providers/WMSEarthTodayProvider.cs
@@ -9,6 +9,13 @@ namespace WWT.Providers
 {
     public class WMSEarthTodayProvider : RequestProvider
     {
+        private readonly IFileNameHasher _hasher;
+
+        public WMSEarthTodayProvider(IFileNameHasher hasher)
+        {
+            _hasher = hasher;
+        }
+
         public override void Run(WwtContext context)
         {
             string query = context.Request.Params["Q"];
@@ -18,7 +25,7 @@ namespace WWT.Providers
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
             string wmsUrl = values[3];
-            string dirPart = Math.Abs(wmsUrl.GetHashCode()).ToString();
+            string dirPart = _hasher.HashName(wmsUrl).ToString();
 
             string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
 

--- a/src/WWT.Providers/Providers/WMSMoonProvider.cs
+++ b/src/WWT.Providers/Providers/WMSMoonProvider.cs
@@ -8,6 +8,13 @@ namespace WWT.Providers
 {
     public class WMSMoonProvider : RequestProvider
     {
+        private readonly IFileNameHasher _hasher;
+
+        public WMSMoonProvider(IFileNameHasher hasher)
+        {
+            _hasher = hasher;
+        }
+
         public override void Run(WwtContext context)
         {
             string query = context.Request.Params["Q"];
@@ -17,7 +24,7 @@ namespace WWT.Providers
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
             string wmsUrl = values[3];
-            string dirPart = Math.Abs(wmsUrl.GetHashCode()).ToString();
+            string dirPart = _hasher.HashName(wmsUrl).ToString();
             string filename;
             string path;
             filename = String.Format("\\\\wwt-sql01\\DSSTileCache\\WMS\\{3}\\{0}\\{2}\\{2}_{1}.png", level, tileX, tileY, dirPart);

--- a/src/WWT.Providers/Providers/WMSToastProvider.cs
+++ b/src/WWT.Providers/Providers/WMSToastProvider.cs
@@ -8,6 +8,13 @@ namespace WWT.Providers
 {
     public class WMSToastProvider : RequestProvider
     {
+        private readonly IFileNameHasher _hasher;
+
+        public WMSToastProvider(IFileNameHasher hasher)
+        {
+            _hasher = hasher;
+        }
+
         public override void Run(WwtContext context)
         {
             string query = context.Request.Params["Q"];
@@ -18,7 +25,7 @@ namespace WWT.Providers
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
             string wmsUrl = values[3];
-            string dirPart = Math.Abs(wmsUrl.GetHashCode()).ToString();
+            string dirPart = _hasher.HashName(wmsUrl).ToString();
             string filename;
             string path;
 

--- a/src/WWT.Providers/Providers/XML2WTT.aspx.cs
+++ b/src/WWT.Providers/Providers/XML2WTT.aspx.cs
@@ -4,11 +4,19 @@ using System.IO;
 using System.Net;
 using System.Text;
 using System.Xml;
+using WWTWebservices;
 
 namespace WWT.Providers
 {
     public abstract partial class WWTWeb_XML2WTT : RequestProvider
     {
+        private readonly IFileNameHasher _hasher;
+
+        public WWTWeb_XML2WTT(IFileNameHasher hasher)
+        {
+            _hasher = hasher;
+        }
+
         protected string MakeTourFromXML(WwtContext context, Stream InputStream, string baseDir)
         {
             XmlDocument doc = new XmlDocument();
@@ -181,24 +189,8 @@ namespace WWT.Providers
             {
             }
 
-
-
-
-            //if (!string.IsNullOrEmpty(voiceUrl))
-            //{
-            //    voicePath = dir + (Math.Abs(voiceUrl.GetHashCode()).ToString());
-            //    if (!File.Exists(voicePath))
-            //    {
-            //        client.DownloadFile(voiceUrl, voicePath);
-            //    }
-            //    cab.AddFile(voicePath, true, tourGuid + "\\voice.wma");
-            //}
-
-
-
             string tourfilename = dir + id.ToString() + ".wttxml";
             File.WriteAllText(tourfilename, sb.ToString(), Encoding.UTF8);
-
 
             cab.AddFile(tourfilename, false, "");
             cab.AddFile(page + "\\images\\zoologo.png", true, tourGuid + "\\zoologo.png");
@@ -207,7 +199,8 @@ namespace WWT.Providers
 
             if (!string.IsNullOrEmpty(musicUrl))
             {
-                musicPath = dir + (Math.Abs(musicUrl.GetHashCode()).ToString());
+                musicPath = $"{dir}{_hasher.HashName(musicUrl)}";
+
                 if (!File.Exists(musicPath))
                 {
                     client.DownloadFile(musicUrl, musicPath);

--- a/src/WWT.Providers/Providers/XML2WTTProvider.cs
+++ b/src/WWT.Providers/Providers/XML2WTTProvider.cs
@@ -1,9 +1,15 @@
 using System.Configuration;
+using WWTWebservices;
 
 namespace WWT.Providers
 {
     public class XML2WTTProvider : WWTWeb_XML2WTT
     {
+        public XML2WTTProvider(IFileNameHasher hasher)
+            : base(hasher)
+        {
+        }
+
         public override void Run(WwtContext context)
         {
             //string etag = context.Request.Headers["If-None-Match"];


### PR DESCRIPTION
This includes an implementation that mimics the 32-bit string
.GetHashCode() implementation so behavior will be the same.