### PR TITLE
Skip null check for entity connection string

### DIFF
--- a/WWTMVC5/Global.asax.cs
+++ b/WWTMVC5/Global.asax.cs
@@ -62,21 +62,21 @@ namespace WWTMVC5
         private static void RegisterUnityContainer()
         {
             _container = new UnityContainer();
-            var earthSettings = ConfigReader<string>.GetSetting("EarthOnlineEntities");
 
-            if (earthSettings is null)
-            {
-                throw new InvalidOperationException("Setting for EarthOnlineEntitites is unavailable");
-            }
-
-            var manager = new PerRequestLifetimeManager();
-            var constructor = new InjectionConstructor(earthSettings);
-            _container.RegisterType<EarthOnlineEntities>(manager, constructor);
-
+            RegisterEarthOnlineEntities(_container);
             RegisterRepositories(_container);
             RegisterServices(_container);
 
             DependencyResolver.SetResolver(new UnityDependencyResolver(_container));
+        }
+
+        private static void RegisterEarthOnlineEntities(UnityContainer container)
+        {
+            var earthSettings = ConfigReader<string>.GetSetting("EarthOnlineEntities") ?? string.Empty;
+            var manager = new PerRequestLifetimeManager();
+            var constructor = new InjectionConstructor(earthSettings);
+
+            container.RegisterType<EarthOnlineEntities>(manager, constructor);
         }
 
         /// <summary>


### PR DESCRIPTION
Currently, if the entity connection string is empty, it will fail at
launch. However, for local dev, this string may not be set and shouldn't
fail until it is used. By using string.Empty, it will still fail, but
only at the point where it is used.