### PR TITLE
Build dotnet CLI tool for plate manager

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,13 @@
-<Project ToolsVersion="14.0"
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <InformationalVersion>$(GitVersion_InformationalVersion)</InformationalVersion>
+    <FileVersion>$(GitVersion_MajorMinorPatch)</FileVersion>
+    <AssemblyVersion>$(GitVersion_AssemblySemVer)</AssemblyVersion>
+    <Version>$(GitVersion_NuGetVersionV2)</Version>
+  </PropertyGroup>
+
 </Project>

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,5 @@
+mode: ContinuousDeployment
+next-version: 0.1.0
+branches: {}
+ignore:
+  sha: []

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,15 @@ variables:
   buildConfiguration: 'Release'
 
 steps:
+- task: PowerShell@2
+  displayName: 'Update version'
+  name: updateVersion
+  inputs:
+    targetType: 'inline'
+    script: |
+      dotnet tool install --global GitVersion.Tool --version 5.1.2      
+      dotnet gitversion /output buildserver /nofetch
+
 - task: NuGetToolInstaller@1
 
 - task: NuGetCommand@2
@@ -36,9 +45,19 @@ steps:
 - task: VSBuild@1
   inputs:
     solution: '$(solution)'
-    msbuildArgs: '/p:DeployOnBuild=true /p:PrecompileBeforePublish=true /p:EnableUpdateable=false /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:PackageLocation="$(build.artifactStagingDirectory)"'
+    msbuildArgs: '/p:DeployOnBuild=true /p:PrecompileBeforePublish=true /p:EnableUpdateable=false /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:PackageLocation="$(build.artifactStagingDirectory)/website"'
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
+
+- task: DotNetCoreCLI@2
+  displayName: Create tool package
+  inputs:
+    command: 'pack'
+    packagesToPack: 'tools/PlateManager/PlateManager.csproj'
+    packDirectory: '$(Build.ArtifactStagingDirectory)/tools'
+    includesymbols: true
+    includesource: true
+    versioningScheme: 'off'
 
 - task: VSTest@2
   inputs:
@@ -51,6 +70,21 @@ steps:
 
 - task: PublishPipelineArtifact@1
   inputs:
-    targetPath: '$(build.artifactStagingDirectory)'
+    targetPath: '$(build.artifactStagingDirectory)/website'
     artifact: 'website'
     publishLocation: 'pipeline'
+
+- task: PublishPipelineArtifact@1
+  inputs:
+    targetPath: '$(build.artifactStagingDirectory)/tools'
+    artifact: 'tools'
+    publishLocation: 'pipeline'
+
+- task: DotNetCoreCLI@2
+  displayName: Push tools to feed
+  inputs:
+    command: 'push'
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/tools/*.nupkg'
+    nuGetFeedType: 'internal'
+    publishVstsFeed: '5b8413f0-309f-4655-933b-c3b9516cd60f/cec2a436-ea5b-41d3-a4d4-8f2380a4c6a9'
+  condition: ne(variables['Build.Reason'], 'PullRequest')

--- a/tools/PlateManager/PlateManager.csproj
+++ b/tools/PlateManager/PlateManager.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>wwt</ToolCommandName>
+    <PackageId>wwt</PackageId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/PlateManager/Program.cs
+++ b/tools/PlateManager/Program.cs
@@ -37,6 +37,11 @@ namespace PlateManager
                 command
             };
 
+            using (var current = System.Diagnostics.Process.GetCurrentProcess())
+            {
+                root.Name = current.ProcessName;
+            }
+
             return root.InvokeAsync(args);
         }
 


### PR DESCRIPTION
Packages the tool as a distributable package that will be installable via `dotnet tool install -g wwt` and then used as `wwt ...`. For now I've created a `wwt-tools` feed on the AAS devops (this can be moved else where if desired), that this will be pushed to on build.

This also uses GitVersion for simple versioning for the tool/website.