### PR TITLE
Add IPlateTilePyramid for DSSToastProvider

### DIFF
--- a/src/WWT.Providers/FilePathOptions.cs
+++ b/src/WWT.Providers/FilePathOptions.cs
@@ -1,0 +1,28 @@
+﻿using System.Configuration;
+using WWTWebservices;
+
+namespace WWT.Providers
+{
+    public class FilePathOptions
+    {
+        public static FilePathOptions CreateFromConfig()
+            => new FilePathOptions
+            {
+                DssTerapixelDir = ConfigurationManager.AppSettings["DssTerapixelDir"],
+                DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true),
+                DssToastPng = WWTUtil.GetCurrentConfigShare("DSSTOASTPNG", true),
+                WWTDEMDir = ConfigurationManager.AppSettings["WWTDEMDir"],
+                WwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"],
+            };
+
+        public string DssTerapixelDir { get; set; }
+
+        public string DSSTileCache { get; set; }
+
+        public string DssToastPng { get; set; }
+
+        public string WWTDEMDir { get; set; }
+
+        public string WwtTilesDir { get; set; }
+    }
+}

--- a/src/WWT.Providers/Providers/DSSProvider.cs
+++ b/src/WWT.Providers/Providers/DSSProvider.cs
@@ -1,22 +1,14 @@
 using System;
-using System.Configuration;
 using WWTWebservices;
 
 namespace WWT.Providers
 {
-    public class DSSOptions
-    {
-        public string WwtTilesDir { get; set; } = ConfigurationManager.AppSettings["WWTTilesDir"];
-
-        public string DssTerapixelDir { get; set; } = ConfigurationManager.AppSettings["DssTerapixelDir"];
-    }
-
     public class DSSProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTile;
-        private readonly DSSOptions _options;
+        private readonly FilePathOptions _options;
 
-        public DSSProvider(IPlateTilePyramid plateTile, DSSOptions options)
+        public DSSProvider(IPlateTilePyramid plateTile, FilePathOptions options)
         {
             _plateTile = plateTile;
             _options = options;

--- a/src/WWT.Providers/Providers/DSSToastProvider.cs
+++ b/src/WWT.Providers/Providers/DSSToastProvider.cs
@@ -7,68 +7,60 @@ namespace WWT.Providers
 {
     public class DSSToastProvider : RequestProvider
     {
+        private readonly IPlateTilePyramid _plateTile;
+        private readonly FilePathOptions _options;
+
+        public DSSToastProvider(IPlateTilePyramid plateTile, FilePathOptions options)
+        {
+            _plateTile = plateTile;
+            _options = options;
+        }
+
         public override void Run(IWwtContext context)
         {
-            string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
-            string dsstoastpng = WWTUtil.GetCurrentConfigShare("DSSTOASTPNG", true);
-
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
             int level = Convert.ToInt32(values[0]);
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
 
-            int octsetlevel = level;
-            string filename;
-
             if (level > 12)
             {
                 context.Response.Write("No image");
                 context.Response.Close();
-                return;
             }
-
-            if (level < 8)
+            else if (level < 8)
             {
                 context.Response.ContentType = "image/png";
-                Stream s = PlateTilePyramid.GetFileStream(wwtTilesDir + "\\dsstoast.plate", level, tileX, tileY);
-                int length = (int)s.Length;
-                byte[] data = new byte[length];
-                s.Read(data, 0, length);
-                context.Response.OutputStream.Write(data, 0, length);
-                context.Response.Flush();
-                context.Response.End();
-                return;
+
+                using (var s = _plateTile.GetStream(_options.WwtTilesDir, "dsstoast.plate", level, tileX, tileY))
+                {
+                    s.CopyTo(context.Response.OutputStream);
+                    context.Response.Flush();
+                    context.Response.End();
+                }
             }
             else
             {
-                int L = level;
-                int X = tileX;
-                int Y = tileY;
-                string mime = "png";
-                int powLev5Diff = (int)Math.Pow(2, L - 5);
-                int X32 = X / powLev5Diff;
-                int Y32 = Y / powLev5Diff;
-                filename = string.Format(dsstoastpng + @"\DSS{0}L5to12_x{1}_y{2}.plate", mime, X32, Y32);
+                int powLev5Diff = (int)Math.Pow(2, level - 5);
+                int X32 = tileX / powLev5Diff;
+                int Y32 = tileY / powLev5Diff;
 
-                int L5 = L - 5;
-                int X5 = X % powLev5Diff;
-                int Y5 = Y % powLev5Diff;
+                int L5 = level - 5;
+                int X5 = tileX % powLev5Diff;
+                int Y5 = tileY % powLev5Diff;
+
                 context.Response.ContentType = "image/png";
-                Stream s = PlateTilePyramid.GetFileStream(filename, L5, X5, Y5);
-                int length = (int)s.Length;
-                byte[] data = new byte[length];
-                s.Read(data, 0, length);
-                context.Response.OutputStream.Write(data, 0, length);
-                context.Response.Flush();
-                context.Response.End();
-                return;
 
+                var filename = $"DSSpngL5to12_x{X32}_y{Y32}.plate";
+
+                using (var s = _plateTile.GetStream(_options.DssToastPng, filename, L5, X5, Y5))
+                {
+                    s.CopyTo(context.Response.OutputStream);
+                    context.Response.Flush();
+                    context.Response.End();
+                }
             }
-
-            // This file has returns which cause this warning to show in the generated files.
-            // This should be refactored, but that will be a bigger change.
-#pragma warning disable 0162
         }
     }
 }

--- a/src/WWTMVC5/App_Start/UnityConfig.cs
+++ b/src/WWTMVC5/App_Start/UnityConfig.cs
@@ -63,6 +63,8 @@ namespace WWTMVC5
             {
                 container.RegisterType(type);
             }
+
+            container.RegisterInstance(FilePathOptions.CreateFromConfig());
         }
 
         private static void RegisterPlateFileProvider(IUnityContainer container)

--- a/tests/WWT.Providers.Tests/DSSToastTests.cs
+++ b/tests/WWT.Providers.Tests/DSSToastTests.cs
@@ -1,4 +1,4 @@
-using AutofacContrib.NSubstitute;
+﻿using AutofacContrib.NSubstitute;
 using AutoFixture;
 using NSubstitute;
 using NSubstitute.Extensions;
@@ -10,11 +10,11 @@ using Xunit;
 
 namespace WWT.Providers.Tests
 {
-    public class DSSTests
+    public class DSSToastTests
     {
         private readonly Fixture _fixture;
 
-        public DSSTests()
+        public DSSToastTests()
         {
             _fixture = new Fixture();
         }
@@ -30,7 +30,7 @@ namespace WWT.Providers.Tests
                 .Build();
 
             // Act
-            container.RunProviderTest<DSSProvider>();
+            container.RunProviderTest<DSSToastProvider>();
 
             // Assert
             container.Resolve<HttpResponseBase>().Received(1).Write("No image");
@@ -57,10 +57,10 @@ namespace WWT.Providers.Tests
             var outputStream = new MemoryStream();
 
             container.Resolve<HttpResponseBase>().Configure().OutputStream.Returns(outputStream);
-            container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, "dssterrapixel.plate", level, x, y).Returns(result);
+            container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, "dsstoast.plate", level, x, y).Returns(result);
 
             // Act
-            container.RunProviderTest<DSSProvider>();
+            container.RunProviderTest<DSSToastProvider>();
 
             // Assert
             Assert.Equal("image/png", container.Resolve<HttpResponseBase>().ContentType);
@@ -89,10 +89,10 @@ namespace WWT.Providers.Tests
             var filename = $"DSSpngL5to12_x{fileX}_y{fileY}.plate";
 
             container.Resolve<HttpResponseBase>().Configure().OutputStream.Returns(outputStream);
-            container.Resolve<IPlateTilePyramid>().GetStream(options.DssTerapixelDir, filename, level2, x2, y2).Returns(result);
+            container.Resolve<IPlateTilePyramid>().GetStream(options.DssToastPng, filename, level2, x2, y2).Returns(result);
 
             // Act
-            container.RunProviderTest<DSSProvider>();
+            container.RunProviderTest<DSSToastProvider>();
 
             // Assert
             Assert.Equal("image/png", container.Resolve<HttpResponseBase>().ContentType);

--- a/tests/WWT.Providers.Tests/HttpAutoSubstituteExtensions.cs
+++ b/tests/WWT.Providers.Tests/HttpAutoSubstituteExtensions.cs
@@ -10,6 +10,12 @@ namespace WWT.Providers.Tests
 {
     internal static class HttpAutoSubstituteExtensions
     {
+        public static void RunProviderTest<T>(this AutoSubstitute container)
+            where T : RequestProvider
+        {
+            container.Resolve<T>().Run(container.Resolve<IWwtContext>());
+        }
+
         public static AutoSubstituteBuilder InitializeHttpWrappers(this AutoSubstituteBuilder builder)
         {
             builder.SubstituteFor2<HttpResponseBase>()
@@ -29,6 +35,9 @@ namespace WWT.Providers.Tests
 
             return builder;
         }
+
+        public static AutoSubstituteBuilder ConfigureParameterQ(this AutoSubstituteBuilder builder, int level, int x, int y)
+            => builder.ConfigureParameters(c => c.Add("Q", $"{level},{x},{y}"));
 
         public static AutoSubstituteBuilder ConfigureParameters(this AutoSubstituteBuilder builder, Action<NameValueCollection> action)
         {


### PR DESCRIPTION
As part of this change, the directory information that was historically retrieved directly from ConfigurationManager is being moved to an options object so that it can be tested, as well as consolidate access points for it.