### PR TITLE
Remove WWTUtil.GetCurrentConfigShare

### DIFF
--- a/src/WWT.Providers/FilePathOptions.cs
+++ b/src/WWT.Providers/FilePathOptions.cs
@@ -9,8 +9,8 @@ namespace WWT.Providers
             => new FilePathOptions
             {
                 DssTerapixelDir = ConfigurationManager.AppSettings["DssTerapixelDir"],
-                DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true),
-                DssToastPng = WWTUtil.GetCurrentConfigShare("DSSTOASTPNG", true),
+                DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"],
+                DssToastPng = ConfigurationManager.AppSettings["DSSTOASTPNG"],
                 WWTDEMDir = ConfigurationManager.AppSettings["WWTDEMDir"],
                 WwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"],
             };

--- a/src/WWT.Providers/Providers/EarthBlendProvider.cs
+++ b/src/WWT.Providers/Providers/EarthBlendProvider.cs
@@ -13,7 +13,7 @@ namespace WWT.Providers
         public override void Run(IWwtContext context)
         {
             string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
             int level = Convert.ToInt32(values[0]);

--- a/src/WWT.Providers/Providers/EarthMerBathProvider.cs
+++ b/src/WWT.Providers/Providers/EarthMerBathProvider.cs
@@ -10,7 +10,7 @@ namespace WWT.Providers
         public override void Run(IWwtContext context)
         {
             string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
-            string dsstoastpng = WWTUtil.GetCurrentConfigShare("DSSTOASTPNG", true);
+            string dsstoastpng = ConfigurationManager.AppSettings["DSSTOASTPNG"];
 
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');

--- a/src/WWT.Providers/Providers/GalexToastProvider.cs
+++ b/src/WWT.Providers/Providers/GalexToastProvider.cs
@@ -16,7 +16,7 @@ namespace WWT.Providers
             int tileY = Convert.ToInt32(values[2]);
 
             string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
-            string wwtgalexdir = WWTUtil.GetCurrentConfigShare("WWTGALEXDIR", true);
+            string wwtgalexdir = ConfigurationManager.AppSettings["WWTGALEXDIR"];
 
 
             if (level > 10)

--- a/src/WWT.Providers/Providers/GetAuthorThumbnailProvider.cs
+++ b/src/WWT.Providers/Providers/GetAuthorThumbnailProvider.cs
@@ -21,7 +21,7 @@ namespace WWT.Providers
             }
             string tourcache = ConfigurationManager.AppSettings["WWTTOURCACHE"];
             string localDir = tourcache;
-            string filename = WWTUtil.GetCurrentConfigShare("WWTToursTourFileUNC", true) + String.Format(@"\{0}_AuthorThumb.bin", guid);
+            string filename = ConfigurationManager.AppSettings["WWTToursTourFileUNC"] + String.Format(@"\{0}_AuthorThumb.bin", guid);
             string localfilename = localDir + String.Format(@"\{0}_AuthorThumb.bin", guid);
 
             if (!File.Exists(localfilename))

--- a/src/WWT.Providers/Providers/GetTileProvider.cs
+++ b/src/WWT.Providers/Providers/GetTileProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Configuration;
 using System.IO;
 using WWTWebservices;
 
@@ -16,7 +17,7 @@ namespace WWT.Providers
             string dataset = values[3];
             string id = dataset;
 
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
 
             string filename = String.Format(DSSTileCache + "\\imagesTiler\\{3}\\{0}\\{2}\\{2}_{1}.png", level, tileX, tileY, id);
 

--- a/src/WWT.Providers/Providers/GetTourProvider.cs
+++ b/src/WWT.Providers/Providers/GetTourProvider.cs
@@ -21,7 +21,7 @@ namespace WWT.Providers
             }
             string tourcache = ConfigurationManager.AppSettings["WWTTOURCACHE"];
             string localDir = tourcache;
-            string filename = WWTUtil.GetCurrentConfigShare("WWTToursTourFileUNC", true) + String.Format(@"\{0}.bin", guid);
+            string filename = ConfigurationManager.AppSettings["WWTToursTourFileUNC"] + String.Format(@"\{0}.bin", guid);
             string localfilename = localDir + String.Format(@"\{0}.bin", guid);
 
             if (!File.Exists(localfilename))

--- a/src/WWT.Providers/Providers/GetTourThumbnailProvider.cs
+++ b/src/WWT.Providers/Providers/GetTourThumbnailProvider.cs
@@ -21,7 +21,7 @@ namespace WWT.Providers
             }
             string tourcache = ConfigurationManager.AppSettings["WWTTOURCACHE"];
             string localDir = tourcache;
-            string filename = WWTUtil.GetCurrentConfigShare("WWTToursTourFileUNC", true) + String.Format(@"\{0}_TourThumb.bin", guid);
+            string filename = ConfigurationManager.AppSettings["WWTToursTourFileUNC"] + String.Format(@"\{0}_TourThumb.bin", guid);
             string localfilename = localDir + String.Format(@"\{0}_TourThumb.bin", guid);
 
             if (!File.Exists(localfilename))

--- a/src/WWT.Providers/Providers/Hirise.aspx.cs
+++ b/src/WWT.Providers/Providers/Hirise.aspx.cs
@@ -12,8 +12,6 @@ namespace WWT.Providers
 
         public Bitmap DownloadBitmap(string dataset, int level, int x, int y)
         {
-            //todo fix this
-            string DSSTileCache = ""; //; Util.GetCurrentConfigShare("DSSTileCache", true);
             string id = "1738422189";
             switch (dataset)
             {
@@ -48,9 +46,9 @@ namespace WWT.Providers
             }
 
 
-            string filename = String.Format(DSSTileCache + "\\wwtcache\\mars\\{3}\\{0}\\{2}\\{1}_{2}.png", level, x, y,
+            string filename = String.Format("\\wwtcache\\mars\\{3}\\{0}\\{2}\\{1}_{2}.png", level, x, y,
                 id);
-            string path = String.Format(DSSTileCache + "\\wwtcache\\mars\\{3}\\{0}\\{2}", level, x, y, id);
+            string path = String.Format("\\wwtcache\\mars\\{3}\\{0}\\{2}", level, x, y, id);
 
 
             if (!File.Exists(filename))

--- a/src/WWT.Providers/Providers/HiriseDem2Provider.cs
+++ b/src/WWT.Providers/Providers/HiriseDem2Provider.cs
@@ -16,7 +16,7 @@ namespace WWT.Providers
             int tileY = Convert.ToInt32(values[2]);
 
             string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
 
             DSSTileCache = @"\\wwt-mars\marsroot";
 

--- a/src/WWT.Providers/Providers/HiriseDem3Provider.cs
+++ b/src/WWT.Providers/Providers/HiriseDem3Provider.cs
@@ -17,7 +17,7 @@ namespace WWT.Providers
 
             string file = "marsToastDem";
             string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
 
             DSSTileCache = @"\\wwt-mars\marsroot";
 

--- a/src/WWT.Providers/Providers/HiriseDemProvider.cs
+++ b/src/WWT.Providers/Providers/HiriseDemProvider.cs
@@ -17,7 +17,7 @@ namespace WWT.Providers
 
             string file = "marsToastDem";
             string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
 
             DSSTileCache = @"\\wwt-mars\marsroot";
 

--- a/src/WWT.Providers/Providers/MandelProvider.cs
+++ b/src/WWT.Providers/Providers/MandelProvider.cs
@@ -21,7 +21,7 @@ namespace WWT.Providers
             string filename;
             string path;
             Bitmap b = null;
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
             string webDir = ConfigurationManager.AppSettings["WWTWEBDIR"];
 
 

--- a/src/WWT.Providers/Providers/MarsHirise.aspx.cs
+++ b/src/WWT.Providers/Providers/MarsHirise.aspx.cs
@@ -1,5 +1,6 @@
 using Microsoft.WindowsAzure.Storage.Blob;
 using System;
+using System.Configuration;
 using System.Drawing;
 using System.IO;
 using WWTWebservices;
@@ -10,7 +11,7 @@ namespace WWT.Providers
     {
         public Bitmap DownloadBitmap(string dataset, int level, int x, int y)
         {
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
             string id = "1738422189";
             switch (dataset)
             {

--- a/src/WWT.Providers/Providers/MarsMoc.aspx.cs
+++ b/src/WWT.Providers/Providers/MarsMoc.aspx.cs
@@ -1,5 +1,6 @@
 using Microsoft.WindowsAzure.Storage.Blob;
 using System;
+using System.Configuration;
 using System.Drawing;
 using System.IO;
 using WWTWebservices;
@@ -10,7 +11,7 @@ namespace WWT.Providers
     {
         public Bitmap DownloadBitmap(string dataset, int level, int x, int y)
         {
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
             string id = "1738422189";
             switch (dataset)
             {

--- a/src/WWT.Providers/Providers/MartianTile2Provider.cs
+++ b/src/WWT.Providers/Providers/MartianTile2Provider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Configuration;
 using System.IO;
 using WWTWebservices;
 
@@ -16,7 +17,7 @@ namespace WWT.Providers
             string dataset = values[3];
             string id = "nothing";
 
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
 
             switch (dataset)
             {

--- a/src/WWT.Providers/Providers/MartianTileEmptyProvider.cs
+++ b/src/WWT.Providers/Providers/MartianTileEmptyProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Configuration;
 using System.IO;
 using System.Net;
 using WWTWebservices;
@@ -18,7 +19,7 @@ namespace WWT.Providers
             string id = "nothing";
             string type = ".png";
 
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
 
             switch (dataset)
             {

--- a/src/WWT.Providers/Providers/MartianTileNewProvider.cs
+++ b/src/WWT.Providers/Providers/MartianTileNewProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Configuration;
 using System.IO;
 using WWTWebservices;
 
@@ -16,7 +17,7 @@ namespace WWT.Providers
             string dataset = values[3];
             string id = "nothing";
 
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
 
             switch (dataset)
             {

--- a/src/WWT.Providers/Providers/MartianTileProvider.cs
+++ b/src/WWT.Providers/Providers/MartianTileProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Configuration;
 using System.IO;
 using WWTWebservices;
 
@@ -16,7 +17,7 @@ namespace WWT.Providers
             string dataset = values[3];
             string id = "nothing";
 
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
 
             switch (dataset)
             {

--- a/src/WWT.Providers/Providers/SDSS12ToastProvider.cs
+++ b/src/WWT.Providers/Providers/SDSS12ToastProvider.cs
@@ -47,7 +47,7 @@ namespace WWT.Providers
             string path;
 
             string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
 
 
 

--- a/src/WWT.Providers/Providers/SDSSToast2Provider.cs
+++ b/src/WWT.Providers/Providers/SDSSToast2Provider.cs
@@ -21,7 +21,7 @@ namespace WWT.Providers
             string filename;
             string path;
             string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
 
 
 

--- a/src/WWT.Providers/Providers/SDSSToastProvider.cs
+++ b/src/WWT.Providers/Providers/SDSSToastProvider.cs
@@ -47,7 +47,7 @@ namespace WWT.Providers
             string path;
 
             string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
 
 
 

--- a/src/WWT.Providers/Providers/TileImage.aspx.cs
+++ b/src/WWT.Providers/Providers/TileImage.aspx.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Drawing;
 using System.IO;
 using System.Xml;
@@ -11,8 +12,6 @@ namespace WWT.Providers
     {
         public Bitmap DownloadBitmap(string dataset, int level, int x, int y)
         {
-            //todo fix this
-            string DSSTileCache = ""; //; Util.GetCurrentConfigShare("DSSTileCache", true);
             string id = "1738422189";
             switch (dataset)
             {
@@ -47,9 +46,9 @@ namespace WWT.Providers
             }
 
 
-            string filename = String.Format(DSSTileCache + "\\wwtcache\\mars\\{3}\\{0}\\{2}\\{1}_{2}.png", level, x, y,
+            string filename = String.Format("\\wwtcache\\mars\\{3}\\{0}\\{2}\\{1}_{2}.png", level, x, y,
                 id);
-            string path = String.Format(DSSTileCache + "\\wwtcache\\mars\\{3}\\{0}\\{2}", level, x, y, id);
+            string path = String.Format("\\wwtcache\\mars\\{3}\\{0}\\{2}", level, x, y, id);
 
 
             if (!File.Exists(filename))
@@ -62,7 +61,7 @@ namespace WWT.Providers
 
         public void TileBitmap(Bitmap bmp, string ID)
         {
-            string baseDirectory = WWTUtil.GetCurrentConfigShare("DSSTileCache", true) + "\\imagesTiler\\";
+            string baseDirectory = ConfigurationManager.AppSettings["DSSTileCache"] + "\\imagesTiler\\";
             int width = bmp.Width;
             int height = bmp.Height;
             double aspect = (double)width / (double)height;
@@ -156,7 +155,7 @@ namespace WWT.Providers
 
         public static void MakeThumbnail(Bitmap imgOrig, string hashID)
         {
-            string path = WWTUtil.GetCurrentConfigShare("DSSTileCache", true) + "\\imagesTiler\\thumbnails\\";
+            string path = ConfigurationManager.AppSettings["DSSTileCache"] + "\\imagesTiler\\thumbnails\\";
 
             string filename = path + hashID + ".jpg";
 

--- a/src/WWT.Providers/Providers/TileImageProvider.cs
+++ b/src/WWT.Providers/Providers/TileImageProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Configuration;
 using System.Drawing;
 using System.IO;
 using System.Net;
@@ -63,7 +64,7 @@ namespace WWT.Providers
                 int hashID = _hasher.HashName(url);
 
                 //hashID = 12345;
-                string path = WWTUtil.GetCurrentConfigShare("DSSTileCache", true) + "\\imagesTiler\\dowloadImages\\";
+                string path = ConfigurationManager.AppSettings["DSSTileCache"] + "\\imagesTiler\\dowloadImages\\";
 
                 string filename = path + hashID + ".png";
 

--- a/src/WWT.Providers/Providers/WMSToastProvider.cs
+++ b/src/WWT.Providers/Providers/WMSToastProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Configuration;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
@@ -29,7 +30,7 @@ namespace WWT.Providers
             string filename;
             string path;
 
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
             filename = String.Format(DSSTileCache + "\\WMS\\{3}\\{0}\\{2}\\{2}_{1}.png", level, tileX, tileY, dirPart);
             path = String.Format(DSSTileCache + "\\WMS\\{3}\\{0}\\{2}", level, tileX, tileY, dirPart);
 

--- a/src/WWT.Providers/Providers/testProvider.cs
+++ b/src/WWT.Providers/Providers/testProvider.cs
@@ -9,62 +9,8 @@ namespace WWT.Providers
     {
         public override void Run(IWwtContext context)
         {
-            string primary = ConfigurationManager.AppSettings["PrimaryFileserver"].ToLower();
-            context.Response.Write("primary: " + primary + "<BR />");
-            string backup = ConfigurationManager.AppSettings["BackupFileserver"].ToLower();
-            context.Response.Write("Secondary: " + backup + "<BR />");
-            string current = (string)HttpContext.Current.Cache.Get("CurrentFileServer");
-            context.Response.Write("Current: " + current + "<BR />");
-
-            DateTime lastCheck = DateTime.Now.AddDays(-1);
-
-            if (!string.IsNullOrEmpty(current) && HttpContext.Current.Cache.Get("LastFileserverUpdateDateTime") != null)
-            {
-                lastCheck = (DateTime)HttpContext.Current.Cache.Get("LastFileserverUpdateDateTime");
-            }
-
-            TimeSpan ts = DateTime.Now - lastCheck;
-
-            if (ts.TotalMinutes > 1)
-            {
-                HttpContext.Current.Cache.Remove("LastFileserverUpdateDateTime");
-                HttpContext.Current.Cache.Add("LastFileserverUpdateDateTime", System.DateTime.Now, null, DateTime.MaxValue, new TimeSpan(24, 0, 0), System.Web.Caching.CacheItemPriority.Normal, null);
-
-
-                if (string.IsNullOrEmpty(current) || !Directory.Exists(@"\\" + current + @"\wwttours"))
-                {
-                    bool primaryUp = false;
-
-                    try
-                    {
-                        primaryUp = Directory.Exists(@"\\" + primary + @"\wwttours");
-
-                        context.Response.Write("  primary: " + primary + @"\wwttours      " + "<BR />");
-                        context.Response.Write("Is primary up: " + primaryUp + "<BR />");
-                    }
-                    catch
-                    {
-                    }
-
-                    if (primaryUp)
-                    {
-                        current = primary;
-                        HttpContext.Current.Cache.Remove("CurrentFileServer");
-                        HttpContext.Current.Cache.Add("CurrentFileServer", current, null, DateTime.MaxValue, new TimeSpan(24, 0, 0), System.Web.Caching.CacheItemPriority.Normal, null);
-
-                    }
-                    else
-                    {
-                        current = backup;
-                        HttpContext.Current.Cache.Remove("CurrentFileServer");
-                        HttpContext.Current.Cache.Add("CurrentFileServer", current, null, DateTime.MaxValue, new TimeSpan(24, 0, 0), System.Web.Caching.CacheItemPriority.Normal, null);
-                    }
-                }
-            }
-
             String baseName = ConfigurationManager.AppSettings["WWTToursTourFileUNC"].ToLower();
-
-            context.Response.Write(baseName.Replace(primary, current));
+            context.Response.Write(baseName);
         }
     }
 }

--- a/src/WWT.Providers/Providers/testfailoverProvider.cs
+++ b/src/WWT.Providers/Providers/testfailoverProvider.cs
@@ -1,3 +1,4 @@
+using System.Configuration;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -6,7 +7,7 @@ namespace WWT.Providers
     {
         public override void Run(IWwtContext context)
         {
-            context.Response.Write(WWTUtil.GetCurrentConfigShare("DSSTOASTPNG", true));
+            context.Response.Write(ConfigurationManager.AppSettings["DSSTOASTPNG"]);
         }
     }
 }

--- a/src/WWT.Providers/Providers/tilethumbProvider.cs
+++ b/src/WWT.Providers/Providers/tilethumbProvider.cs
@@ -1,3 +1,4 @@
+using System.Configuration;
 using System.IO;
 using WWTWebservices;
 
@@ -9,7 +10,7 @@ namespace WWT.Providers
         {
             string name = context.Request.Params["name"];
             string type = context.Request.Params["class"];
-            string path = WWTUtil.GetCurrentConfigShare("DSSTileCache", true) + "\\imagesTiler\\thumbnails\\";
+            string path = ConfigurationManager.AppSettings["DSSTileCache"] + "\\imagesTiler\\thumbnails\\";
 
             string filename = path + name + ".jpg";
             if (File.Exists(filename))

--- a/src/WWT.Providers/Providers/veblendProvider.cs
+++ b/src/WWT.Providers/Providers/veblendProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Configuration;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
@@ -36,7 +37,7 @@ namespace WWT.Providers
             string filename;
             string path;
 
-            string DSSTileCache = WWTUtil.GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
             filename = String.Format(DSSTileCache + "\\VE\\level{0}\\{2}\\{1}_{2}.jpg", level, tileX, tileY);
             path = String.Format(DSSTileCache + "\\VE\\level{0}\\{2}", level, tileX, tileY);
 

--- a/src/WWTMVC5/Web.config
+++ b/src/WWTMVC5/Web.config
@@ -149,8 +149,6 @@ Content-Type: application/x-wt-->
     <add key="WWT2DIR" value=""/>
     <add key="WWTWEBDIR" value=""/>
     <add key="WWTTOURCACHE" value=""/>
-    <add key="PrimaryFileserver" value=""/>
-    <add key="BackupFileserver" value=""/>
     <add key="DSSTileCache" value=""/>
     <add key="WWTToursTourFileUNC" value=""/>
     <add key="DSSTOASTPNG" value=""/>

--- a/src/WWTMVC5/hello.aspx
+++ b/src/WWTMVC5/hello.aspx
@@ -11,7 +11,7 @@
     <form id="form1" runat="server">
     <div>
     <h1>WWT Running on Server <% = System.Environment.MachineName %></h1>
-    <h1>WWT File Server <% = WWTUtil.GetCurrentConfigShare("DSSTOASTPNG", true) %></h1>
+    <h1>WWT File Server <% = ConfigurationManager.AppSettings["DSSTOASTPNG"] %></h1>
     <h1>URL was Running on <% =  Server.HtmlEncode(Request.RawUrl) %></h1>
    <h1>URL was Running on <% =  Request.Headers["host"] %></h1>
     </div>

--- a/src/WWTMVC5/hello2.aspx
+++ b/src/WWTMVC5/hello2.aspx
@@ -12,7 +12,7 @@
     <div>
     <h1>WWT Running on Server <% = System.Environment.MachineName %></h1>
    <h1>WWT Running on Username <% = System.Environment.UserName %></h1>
-    <h1>WWT File Server <% = WWTUtil.GetCurrentConfigShare("DSSTOASTPNG", true) %></h1>
+    <h1>WWT File Server <% = ConfigurationManager.AppSettings["DSSTOASTPNG"] %></h1>
     <h1>URL was Running on <% =  Server.HtmlEncode(Request.RawUrl) %></h1>
    <h1>URL was Running on <% =  Request.Headers["host"] %></h1>
    

--- a/src/WWTWebservices/WWTUtil.cs
+++ b/src/WWTWebservices/WWTUtil.cs
@@ -14,74 +14,6 @@ namespace WWTWebservices
         {
         }
 
-        public static string GetCurrentConfigShare(string entryName, bool checkAlive)
-        {
-            string primary = ConfigurationManager.AppSettings["PrimaryFileserver"].ToLower();
-            string backup = ConfigurationManager.AppSettings["BackupFileserver"].ToLower();
-
-            string current = (string) HttpContext.Current.Cache.Get("CurrentFileServer");
-
-            if (checkAlive || string.IsNullOrEmpty(current))
-            {
-                DateTime lastCheck = DateTime.Now.AddDays(-1);
-
-                if (!string.IsNullOrEmpty(current) &&
-                    HttpContext.Current.Cache.Get("LastFileserverUpdateDateTime") != null)
-                {
-                    lastCheck = (DateTime) HttpContext.Current.Cache.Get("LastFileserverUpdateDateTime");
-                }
-
-                TimeSpan ts = DateTime.Now - lastCheck;
-
-                if (ts.TotalMinutes > 1)
-                {
-                    HttpContext.Current.Cache.Remove("LastFileserverUpdateDateTime");
-                    HttpContext.Current.Cache.Add("LastFileserverUpdateDateTime", System.DateTime.Now, null,
-                        DateTime.MaxValue, new TimeSpan(24, 0, 0), System.Web.Caching.CacheItemPriority.Normal, null);
-
-
-                    if (string.IsNullOrEmpty(current) || !Directory.Exists(@"\\" + current + @"\DSSTileCache\dsstoast"))
-                    {
-                        bool primaryUp = false;
-
-                        try
-                        {
-                            primaryUp = Directory.Exists(@"\\" + primary + @"\DSSTileCache\dsstoast");
-
-                        }
-                        catch
-                        {
-                        }
-
-                        if (primaryUp)
-                        {
-                            current = primary;
-                            HttpContext.Current.Cache.Remove("CurrentFileServer");
-                            HttpContext.Current.Cache.Add("CurrentFileServer", current, null, DateTime.MaxValue,
-                                new TimeSpan(24, 0, 0), System.Web.Caching.CacheItemPriority.Normal, null);
-
-                        }
-                        else
-                        {
-                            current = backup;
-                            HttpContext.Current.Cache.Remove("CurrentFileServer");
-                            HttpContext.Current.Cache.Add("CurrentFileServer", current, null, DateTime.MaxValue,
-                                new TimeSpan(24, 0, 0), System.Web.Caching.CacheItemPriority.Normal, null);
-                        }
-                    }
-                }
-            }
-
-            string baseName = ConfigurationManager.AppSettings[entryName].ToLower();
-
-            if(string.IsNullOrEmpty(primary))
-            {
-                return baseName;
-            }
-
-            return baseName.Replace(primary, current);
-        }
-
         public static bool ShouldDownloadSDSS(int level, int xtile, int ytile)
         {
             // SDSS boundaries
@@ -192,7 +124,7 @@ namespace WWTWebservices
 
         public static string DownloadVeTile(int level, int tileX, int tileY, bool temp)
         {
-            string DSSTileCache = GetCurrentConfigShare("DSSTileCache", true);
+            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
             string filename = String.Format(DSSTileCache + "\\VE\\level{0}\\{2}\\{1}_{2}.jpg", level, tileX, tileY);
             string path = String.Format(DSSTileCache + "\\VE\\level{0}\\{2}", level, tileX, tileY);
 


### PR DESCRIPTION
This whole infrastructure implemented a basic failover scheme that isn't even used in the current production system, and it certainly isn't something that we want to bring back in the new system.

This change introduces a small behavior change because GetCurrentConfigShare called `ToLower()` on the config value that it returned. We don't do that here, which shouldn't cause any problems.

Change prepared on my Linux machine without even compiling, so this might take a few tries to get right.