### PR TITLE
Update for AutoSubstitute 6.1.0

### DIFF
--- a/tests/Common/AutoSubstituteExtensions.cs
+++ b/tests/Common/AutoSubstituteExtensions.cs
@@ -1,91 +1,18 @@
 using Autofac;
 using NSubstitute;
+using NSubstitute.Extensions;
 using System;
 
 namespace AutofacContrib.NSubstitute
 {
-    /// <summary>
-    /// This can be replaced by https://github.com/MRCollective/AutofacContrib.NSubstitute/pull/41 once it's merged in and available
-    /// </summary>
     internal static class AutoSubstituteExtensions
     {
-        public static SubstituteForBuilder2<T> SubstituteFor2<T>(this AutoSubstituteBuilder builder)
+        public static SubstituteForBuilder<T> ResolveReturnValue<T, TResult>(this SubstituteForBuilder<T> builder, Func<T, TResult> action)
             where T : class
-        {
-            builder.ConfigureBuilder(b =>
+            => builder.ConfigureSubstitute((t, ctx) =>
             {
-                b.Register(_ => Substitute.For<T>())
-                    .As<T>()
-                    .InstancePerLifetimeScope();
+                var s = ctx.Resolve<TResult>();
+                action(t.Configure()).Returns(s);
             });
-
-            return new SubstituteForBuilder2<T>(builder);
-        }
-
-        public class SubstituteForBuilder2<TService>
-            where TService : class
-        {
-            private readonly AutoSubstituteBuilder _builder;
-
-            internal SubstituteForBuilder2(AutoSubstituteBuilder builder)
-            {
-                _builder = builder;
-            }
-
-            /// <summary>
-            /// Allows for configuration of the service.
-            /// </summary>
-            /// <param name="action">The delegate to configure the service.</param>
-            /// <returns>The original <see cref="AutoSubstituteBuilder"/>.</returns>
-            public AutoSubstituteBuilder Configure(Action<TService> action)
-                => Configure((s, _) => action(s));
-
-            /// <summary>
-            /// Allows for configuration of the service with access to the resolved components.
-            /// </summary>
-            /// <param name="action">The delegate to configure the service.</param>
-            /// <returns>The original <see cref="AutoSubstituteBuilder"/>.</returns>
-            public AutoSubstituteBuilder Configure(Action<TService, IComponentContext> action)
-                => _builder.ConfigureBuilder(builder =>
-                {
-                    builder.RegisterBuildCallback(context =>
-                    {
-                        action(context.Resolve<TService>(), context);
-                    });
-                });
-
-            /// <summary>
-            /// Completes the configuration of the substitute.
-            /// </summary>
-            /// <returns>The original <see cref="AutoSubstituteBuilder"/>.</returns>
-            public AutoSubstituteBuilder Configured()
-                => _builder;
-
-            /// <summary>
-            /// Allows a way to access the services being configured that the container will provide.
-            /// </summary>
-            /// <param name="service">Parameter to obtain the substituted value.</param>
-            /// <returns></returns>
-            public SubstituteForBuilder2<TService> Provide(out IProvidedValue<TService> service)
-            {
-                var provided = new ProvidedValue<TService>();
-
-                _builder.ConfigureBuilder(b =>
-                {
-                    b.RegisterBuildCallback(scope =>
-                    {
-                        provided.Value = scope.Resolve<TService>();
-                    });
-                });
-
-                service = provided;
-                return this;
-            }
-
-            private class ProvidedValue<T> : IProvidedValue<T>
-            {
-                public T Value { get; set; }
-            }
-        }
     }
 }

--- a/tests/Directory.Build.Targets
+++ b/tests/Directory.Build.Targets
@@ -6,7 +6,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutofacContrib.NSubstitute" Version="6.0.0" />
+    <PackageReference Include="AutofacContrib.NSubstitute" Version="6.1.0" />
     <PackageReference Include="AutoFixture" Version="4.14.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/WWT.Providers.Tests/DSSTests.cs
+++ b/tests/WWT.Providers.Tests/DSSTests.cs
@@ -25,7 +25,7 @@ namespace WWT.Providers.Tests
         {
             // Arrange
             using var container = AutoSubstitute.Configure()
-                .InitializeHttpWrappers()
+                .InitializeProviderTests()
                 .ConfigureParameters(a => a.Add("Q", $"{level},2,3"))
                 .Build();
 
@@ -47,7 +47,7 @@ namespace WWT.Providers.Tests
             var options = _fixture.Create<FilePathOptions>();
 
             using var container = AutoSubstitute.Configure()
-                .InitializeHttpWrappers()
+                .InitializeProviderTests()
                 .Provide(options)
                 .ConfigureParameters(a => a.Add("Q", $"{level},{x},{y}"))
                 .Build();
@@ -78,7 +78,7 @@ namespace WWT.Providers.Tests
             var options = _fixture.Create<FilePathOptions>();
 
             using var container = AutoSubstitute.Configure()
-                .InitializeHttpWrappers()
+                .InitializeProviderTests()
                 .Provide(options)
                 .ConfigureParameters(a => a.Add("Q", $"{level},{x},{y}"))
                 .Build();

--- a/tests/WWT.Providers.Tests/DSSToastTests.cs
+++ b/tests/WWT.Providers.Tests/DSSToastTests.cs
@@ -25,7 +25,7 @@ namespace WWT.Providers.Tests
         {
             // Arrange
             using var container = AutoSubstitute.Configure()
-                .InitializeHttpWrappers()
+                .InitializeProviderTests()
                 .ConfigureParameters(a => a.Add("Q", $"{level},2,3"))
                 .Build();
 
@@ -47,7 +47,7 @@ namespace WWT.Providers.Tests
             var options = _fixture.Create<FilePathOptions>();
 
             using var container = AutoSubstitute.Configure()
-                .InitializeHttpWrappers()
+                .InitializeProviderTests()
                 .Provide(options)
                 .ConfigureParameters(a => a.Add("Q", $"{level},{x},{y}"))
                 .Build();
@@ -78,7 +78,7 @@ namespace WWT.Providers.Tests
             var options = _fixture.Create<FilePathOptions>();
 
             using var container = AutoSubstitute.Configure()
-                .InitializeHttpWrappers()
+                .InitializeProviderTests()
                 .Provide(options)
                 .ConfigureParameters(a => a.Add("Q", $"{level},{x},{y}"))
                 .Build();

--- a/tests/WWT.Providers.Tests/DemMarsNewProviderTests.cs
+++ b/tests/WWT.Providers.Tests/DemMarsNewProviderTests.cs
@@ -29,7 +29,7 @@ namespace WWT.Providers.Tests
             var data = _fixture.CreateMany<byte>().ToArray();
             var hash = DirectoryEntry.ComputeHash(level + 128, x, y) % 400;
             using var container = AutoSubstitute.Configure()
-                .InitializeHttpWrappers()
+                .InitializeProviderTests()
                 .ConfigureParameterQ(level, x, y)
                 .Build();
             container.Resolve<IPlateTilePyramid>().GetStream(Prefix, $"marsToastDem_{hash}.plate", -1, level, x, y).Returns(new MemoryStream(data));
@@ -54,7 +54,7 @@ namespace WWT.Providers.Tests
             var hash = DirectoryEntry.ComputeHash(level + 128, x, y) % 400;
 
             using var container = AutoSubstitute.Configure()
-                .InitializeHttpWrappers()
+                .InitializeProviderTests()
                 .ConfigureParameterQ(level, x, y)
                 .Build();
 

--- a/tests/WWT.Providers.Tests/DemMarsProviderTests.cs
+++ b/tests/WWT.Providers.Tests/DemMarsProviderTests.cs
@@ -29,7 +29,7 @@ namespace WWT.Providers.Tests
             // Arrange
             var data = _fixture.CreateMany<byte>().ToArray();
             using var container = AutoSubstitute.Configure()
-                .InitializeHttpWrappers()
+                .InitializeProviderTests()
                 .ConfigureParameterQ(level, x, y)
                 .Build();
             container.Resolve<IPlateTilePyramid>().GetStream(Prefix, PlateName, -1, level, x, y).Returns(new MemoryStream(data));
@@ -53,7 +53,7 @@ namespace WWT.Providers.Tests
             var y = _fixture.Create<int>();
 
             using var container = AutoSubstitute.Configure()
-                .InitializeHttpWrappers()
+                .InitializeProviderTests()
                 .ConfigureParameterQ(level, x, y)
                 .Build();
 

--- a/tests/WWT.Providers.Tests/DustToastProviderTests.cs
+++ b/tests/WWT.Providers.Tests/DustToastProviderTests.cs
@@ -25,7 +25,7 @@ namespace WWT.Providers.Tests
         {
             // Arrange
             using var container = AutoSubstitute.Configure()
-                .InitializeHttpWrappers()
+                .InitializeProviderTests()
                 .ConfigureParameters(a => a.Add("Q", $"{level},2,3"))
                 .Build();
 
@@ -47,7 +47,7 @@ namespace WWT.Providers.Tests
             var options = _fixture.Create<FilePathOptions>();
 
             using var container = AutoSubstitute.Configure()
-                .InitializeHttpWrappers()
+                .InitializeProviderTests()
                 .Provide(options)
                 .ConfigureParameters(a => a.Add("Q", $"{level},{x},{y}"))
                 .Build();

--- a/tests/WWT.Providers.Tests/HttpAutoSubstituteExtensions.cs
+++ b/tests/WWT.Providers.Tests/HttpAutoSubstituteExtensions.cs
@@ -29,38 +29,28 @@ namespace WWT.Providers.Tests
             container.Resolve<T>().Run(container.Resolve<IWwtContext>());
         }
 
-        public static AutoSubstituteBuilder InitializeHttpWrappers(this AutoSubstituteBuilder builder)
-        {
-            builder.SubstituteFor2<HttpResponseBase>()
-                .Configure((b, ctx) =>
-                {
-                    b.Configure().OutputStream.Returns(new MemoryStream());
-                    b.When(bb => bb.Write(Arg.Any<string>())).DoNotCallBase();
-                    b.When(bb => bb.Close()).DoNotCallBase();
-
-                    ctx.Resolve<IWwtContext>().Response.Returns(b);
-                });
-
-            builder.SubstituteFor2<HttpRequestBase>()
-                .Configure((b, ctx) =>
-                {
-                    ctx.Resolve<IWwtContext>().Request.Returns(b);
-                });
-
-            return builder;
-        }
+        public static AutoSubstituteBuilder InitializeProviderTests(this AutoSubstituteBuilder builder)
+            => builder
+                .InjectProperties()
+                .MakeUnregisteredTypesPerLifetime()
+                .SubstituteFor<HttpResponseBase>()
+                    .ConfigureSubstitute(b =>
+                    {
+                        b.Configure().OutputStream.Returns(new MemoryStream());
+                        b.Configure().ContentType.Returns(string.Empty);
+                    })
+                .SubstituteFor<HttpRequestBase>();
 
         public static AutoSubstituteBuilder ConfigureParameterQ(this AutoSubstituteBuilder builder, int level, int x, int y)
             => builder.ConfigureParameters(c => c.Add("Q", $"{level},{x},{y}"));
 
         public static AutoSubstituteBuilder ConfigureParameters(this AutoSubstituteBuilder builder, Action<NameValueCollection> action)
-        {
-            var collection = new NameValueCollection();
-
-            action(collection);
-
-            return builder.SubstituteFor2<HttpRequestBase>()
-                .Configure(b => b.Configure().Params.Returns(collection));
-        }
+            => builder.ConfigureBuilder(b =>
+            {
+                b.RegisterBuildCallback(ctx =>
+                {
+                    action(ctx.Resolve<NameValueCollection>());
+                });
+            });
     }
 }


### PR DESCRIPTION
This allows us to remove some hacks we were doing before with new APIs added in the latest version.