### PR TITLE
Replace abstractions with interfaces

### DIFF
--- a/src/WWT.Providers/IHeaders.cs
+++ b/src/WWT.Providers/IHeaders.cs
@@ -1,0 +1,7 @@
+﻿namespace WWT.Providers
+{
+    public interface IHeaders
+    {
+        string this[string p] { get; }
+    }
+}

--- a/src/WWT.Providers/IParameters.cs
+++ b/src/WWT.Providers/IParameters.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Specialized;
+
+namespace WWT.Providers
+{
+    public interface IParameters
+    {
+        string this[string p] { get; }
+    }
+}

--- a/src/WWT.Providers/IRequest.cs
+++ b/src/WWT.Providers/IRequest.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.IO;
+
+namespace WWT.Providers
+{
+    public interface IRequest
+    {
+        IParameters Params { get; }
+
+        IHeaders Headers { get; }
+
+        bool ContainsCookie(string name);
+
+        string GetParams(string name);
+
+        Uri Url { get; }
+
+        string UserAgent { get; }
+
+        string PhysicalPath { get; }
+
+        Stream InputStream { get; }
+    }
+}

--- a/src/WWT.Providers/IResponse.cs
+++ b/src/WWT.Providers/IResponse.cs
@@ -1,0 +1,39 @@
+﻿using System.IO;
+
+namespace WWT.Providers
+{
+    public interface IResponse
+    {
+        void BinaryWrite(byte[] data);
+
+        void End();
+
+        void Clear();
+
+        string ContentType { get; set; }
+
+        void AddHeader(string name, string value);
+
+        void WriteFile(string path);
+
+        string Status { get; set; }
+
+        int StatusCode { get; set; }
+
+        void Write(string message);
+
+        void Flush();
+
+        Stream OutputStream { get; }
+
+        void Close();
+
+        void ClearHeaders();
+
+        void Redirect(string redirectUri);
+
+        int Expires { get; set; }
+
+        string CacheControl { get; set; }
+    }
+}

--- a/src/WWT.Providers/IWwtContext.cs
+++ b/src/WWT.Providers/IWwtContext.cs
@@ -1,13 +1,13 @@
-﻿using System.Web;
-
-namespace WWT.Providers
+﻿namespace WWT.Providers
 {
     public interface IWwtContext
     {
-        HttpRequestBase Request { get; }
+        IRequest Request { get; }
 
-        HttpResponseBase Response { get; }
+        IResponse Response { get; }
 
-        HttpServerUtilityBase Server { get; }
+        string MachineName { get; }
+
+        string MapPath(string path);
     }
 }

--- a/src/WWT.Providers/PageWwtContext.cs
+++ b/src/WWT.Providers/PageWwtContext.cs
@@ -1,21 +1,86 @@
-﻿using System.Web;
+﻿using System;
+using System.IO;
 using System.Web.UI;
 
 namespace WWT.Providers
 {
-    internal class PageWwtContext : IWwtContext
+    internal class PageWwtContext : IWwtContext, IRequest, IResponse, IHeaders, IParameters
     {
+        private readonly Page _page;
+
         public PageWwtContext(Page page)
         {
-            Request = new HttpRequestWrapper(page.Request);
-            Response = new HttpResponseWrapper(page.Response);
-            Server = new HttpServerUtilityWrapper(page.Server);
+            _page = page;
         }
 
-        public HttpRequestBase Request { get; }
+        public string MachineName => _page.Server.MachineName;
 
-        public HttpResponseBase Response { get; }
+        public string MapPath(string path) => _page.Server.MapPath(path);
 
-        public HttpServerUtilityBase Server { get; }
+        public IRequest Request => this;
+
+        public IResponse Response => this;
+
+        string IRequest.GetParams(string name) => _page.Request.Params[name];
+
+        string IHeaders.this[string name]=> _page.Request.Headers[name];
+
+        string IParameters.this[string name]=> _page.Request.Params[name];
+
+        IParameters IRequest.Params => this;
+
+        IHeaders IRequest.Headers => this;
+
+        Uri IRequest.Url => _page.Request.Url;
+
+        bool IRequest.ContainsCookie(string name) => _page.Request.Cookies[name] != null;
+
+        string IRequest.UserAgent => _page.Request.UserAgent;
+
+        string IRequest.PhysicalPath => _page.Request.PhysicalPath;
+
+        Stream IRequest.InputStream => _page.Request.InputStream;
+
+        string IResponse.ContentType
+        {
+            get => _page.Response.ContentType;
+            set => _page.Response.ContentType = value;
+        }
+
+        string IResponse.Status
+        {
+            get => _page.Response.Status;
+            set => _page.Response.Status = value;
+        }
+
+        int IResponse.StatusCode
+        {
+            get => _page.Response.StatusCode;
+            set => _page.Response.StatusCode = value;
+        }
+
+        Stream IResponse.OutputStream => _page.Response.OutputStream;
+
+        int IResponse.Expires
+        {
+            get => _page.Response.Expires;
+            set => _page.Response.Expires = value;
+        }
+
+        string IResponse.CacheControl
+        {
+            get => _page.Response.CacheControl;
+            set => _page.Response.CacheControl = value;
+        }
+        void IResponse.AddHeader(string name, string value) => _page.Response.AddHeader(name, value);
+        void IResponse.BinaryWrite(byte[] data) => _page.Response.BinaryWrite(data);
+        void IResponse.Clear() => _page.Response.Clear();
+        void IResponse.ClearHeaders() => _page.Response.ClearHeaders();
+        void IResponse.Close() => _page.Response.Close();
+        void IResponse.End() => _page.Response.End();
+        void IResponse.Flush() => _page.Response.Flush();
+        void IResponse.Redirect(string redirectUri) => _page.Response.Redirect(redirectUri);
+        void IResponse.Write(string message) => _page.Response.Write(message);
+        void IResponse.WriteFile(string path) => _page.Response.WriteFile(path);
     }
 }

--- a/src/WWT.Providers/Providers/GetHostNameProvider.cs
+++ b/src/WWT.Providers/Providers/GetHostNameProvider.cs
@@ -4,7 +4,7 @@ namespace WWT.Providers
     {
         public override void Run(IWwtContext context)
         {
-            context.Response.Write(context.Server.MachineName);
+            context.Response.Write(context.MachineName);
         }
     }
 }

--- a/src/WWT.Providers/Providers/GetTourFileProvider.cs
+++ b/src/WWT.Providers/Providers/GetTourFileProvider.cs
@@ -16,7 +16,7 @@ namespace WWT.Providers
 
         public override void Run(IWwtContext context)
         {
-            string path = context.Server.MapPath(@"TourCache");
+            string path = context.MapPath(@"TourCache");
 
             try
             {
@@ -43,8 +43,13 @@ namespace WWT.Providers
                         }
                     }
 
+                    var (contentType, result) = FileCabinet.Extract(filename, targetfile);
 
-                    FileCabinet.Extract(filename, targetfile, context.Response);
+                    if (result != null)
+                    {
+                        context.Response.ContentType = contentType;
+                        context.Response.OutputStream.Write(result, 0, result.Length);
+                    }
                 }
             }
             catch (Exception e)

--- a/src/WWT.Providers/Providers/Goto2Provider.cs
+++ b/src/WWT.Providers/Providers/Goto2Provider.cs
@@ -7,7 +7,7 @@ namespace WWT.Providers
     {
         public override void Run(IWwtContext context)
         {
-            if (context.Request.Cookies["alphakey"] != null && context.Request.Params["wtml"] == null)
+            if (context.Request.ContainsCookie("alphakey") && context.Request.Params["wtml"] == null)
             {
                 context.Response.Redirect("http://www.worldwidetelescope.org/webclient/default.aspx?wtml=" + HttpUtility.UrlEncode(context.Request.Url.ToString() + "&wtml=true"));
                 return;

--- a/src/WWT.Providers/Providers/GotoProvider.cs
+++ b/src/WWT.Providers/Providers/GotoProvider.cs
@@ -7,8 +7,7 @@ namespace WWT.Providers
     {
         public override void Run(IWwtContext context)
         {
-            //if (context.Request.Cookies["alphakey"] != null && context.Request.Params["wtml"] == null)
-            if (context.Request.Cookies["fullclient"] == null && context.Request.Params["wtml"] == null)
+            if (!context.Request.ContainsCookie("fullclient") && context.Request.Params["wtml"] == null)
             {
                 context.Response.Redirect("http://www.worldwidetelescope.org/webclient/default.aspx?wtml=" + HttpUtility.UrlEncode(context.Request.Url.ToString() + "&wtml=true"));
                 return;

--- a/src/WWT.Providers/Providers/ShowImage2Provider.cs
+++ b/src/WWT.Providers/Providers/ShowImage2Provider.cs
@@ -7,7 +7,7 @@ namespace WWT.Providers
     {
         public override void Run(IWwtContext context)
         {
-            if (context.Request.Cookies["alphakey"] != null)// && context.Request.Params["wtml"] == null)
+            if (context.Request.ContainsCookie("alphakey"))
             {
                 context.Response.Redirect("http://www.worldwidetelescope.org/webclient/default.aspx?Wtml=" + HttpUtility.UrlEncode(context.Request.Url.ToString() + "&wtml=true"));
                 return;

--- a/src/WWT.Providers/Providers/ShowImageProvider.cs
+++ b/src/WWT.Providers/Providers/ShowImageProvider.cs
@@ -7,8 +7,7 @@ namespace WWT.Providers
     {
         public override void Run(IWwtContext context)
         {
-            //if (context.Request.Cookies["alphakey"] != null && context.Request.Params["wtml"] == null)
-            if (context.Request.Cookies["fullclient"] == null && context.Request.Params["wtml"] == null)
+            if (!context.Request.ContainsCookie("fullclient") && context.Request.Params["wtml"] == null)
             {
                 context.Response.Redirect("http://www.worldwidetelescope.org/webclient/default.aspx?wtml=" + HttpUtility.UrlEncode(context.Request.Url.ToString().Replace(",", "-") + "&wtml=true"));
                 return;

--- a/src/WWTWebservices/FileCabinet.cs
+++ b/src/WWTWebservices/FileCabinet.cs
@@ -23,7 +23,7 @@ namespace WWTWebservices
     }
     public class FileCabinet
     {
-        public static void Extract(string cabfile, string filetarget, HttpResponseBase response)
+        public static (string contentType, byte[] data) Extract(string cabfile, string filetarget)
         {
 
             //try
@@ -90,9 +90,9 @@ namespace WWTWebservices
 
                             buffer = UnGzip(buffer);
 
-                            response.ContentType = GetMimeTypoForFile(entry.Filename);
-                            response.OutputStream.Write(buffer, 0, buffer.Length);
-                            return;
+                            var contentType = GetMimeTypoForFile(entry.Filename);
+
+                            return (contentType, buffer);
                         }
 
                     }
@@ -106,6 +106,7 @@ namespace WWTWebservices
                 //  UiTools.ShowMessageBox("The data cabinet file was not found. WWT will now download all data from network.");
             }
 
+            return default;
         }
 
         static byte[] UnGzip(byte[] buffer)

--- a/tests/WWT.Providers.Tests/DSSTests.cs
+++ b/tests/WWT.Providers.Tests/DSSTests.cs
@@ -26,14 +26,14 @@ namespace WWT.Providers.Tests
             // Arrange
             using var container = AutoSubstitute.Configure()
                 .InitializeProviderTests()
-                .ConfigureParameters(a => a.Add("Q", $"{level},2,3"))
+                .ConfigureParameterQ(level, 2, 3)
                 .Build();
 
             // Act
             container.RunProviderTest<DSSProvider>();
 
             // Assert
-            container.Resolve<HttpResponseBase>().Received(1).Write("No image");
+            container.Resolve<IResponse>().Received(1).Write("No image");
         }
 
         [Theory]
@@ -49,21 +49,21 @@ namespace WWT.Providers.Tests
             using var container = AutoSubstitute.Configure()
                 .InitializeProviderTests()
                 .Provide(options)
-                .ConfigureParameters(a => a.Add("Q", $"{level},{x},{y}"))
+                .ConfigureParameterQ(level, x, y)
                 .Build();
 
             var data = _fixture.CreateMany<byte>(10);
             var result = new MemoryStream(data.ToArray());
             var outputStream = new MemoryStream();
 
-            container.Resolve<HttpResponseBase>().Configure().OutputStream.Returns(outputStream);
+            container.Resolve<IResponse>().Configure().OutputStream.Returns(outputStream);
             container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, "dssterrapixel.plate", level, x, y).Returns(result);
 
             // Act
             container.RunProviderTest<DSSProvider>();
 
             // Assert
-            Assert.Equal("image/png", container.Resolve<HttpResponseBase>().ContentType);
+            Assert.Equal("image/png", container.Resolve<IResponse>().ContentType);
             Assert.Equal(data, outputStream.ToArray());
         }
 
@@ -80,7 +80,7 @@ namespace WWT.Providers.Tests
             using var container = AutoSubstitute.Configure()
                 .InitializeProviderTests()
                 .Provide(options)
-                .ConfigureParameters(a => a.Add("Q", $"{level},{x},{y}"))
+                .ConfigureParameterQ(level, x, y)
                 .Build();
 
             var data = _fixture.CreateMany<byte>(10);
@@ -88,14 +88,14 @@ namespace WWT.Providers.Tests
             var outputStream = new MemoryStream();
             var filename = $"DSSpngL5to12_x{fileX}_y{fileY}.plate";
 
-            container.Resolve<HttpResponseBase>().Configure().OutputStream.Returns(outputStream);
+            container.Resolve<IResponse>().Configure().OutputStream.Returns(outputStream);
             container.Resolve<IPlateTilePyramid>().GetStream(options.DssTerapixelDir, filename, level2, x2, y2).Returns(result);
 
             // Act
             container.RunProviderTest<DSSProvider>();
 
             // Assert
-            Assert.Equal("image/png", container.Resolve<HttpResponseBase>().ContentType);
+            Assert.Equal("image/png", container.Resolve<IResponse>().ContentType);
             Assert.Equal(data, outputStream.ToArray());
         }
     }

--- a/tests/WWT.Providers.Tests/DSSToastTests.cs
+++ b/tests/WWT.Providers.Tests/DSSToastTests.cs
@@ -26,14 +26,14 @@ namespace WWT.Providers.Tests
             // Arrange
             using var container = AutoSubstitute.Configure()
                 .InitializeProviderTests()
-                .ConfigureParameters(a => a.Add("Q", $"{level},2,3"))
+                .ConfigureParameterQ(level, 2, 3)
                 .Build();
 
             // Act
             container.RunProviderTest<DSSToastProvider>();
 
             // Assert
-            container.Resolve<HttpResponseBase>().Received(1).Write("No image");
+            container.Resolve<IResponse>().Received(1).Write("No image");
         }
 
         [Theory]
@@ -49,21 +49,21 @@ namespace WWT.Providers.Tests
             using var container = AutoSubstitute.Configure()
                 .InitializeProviderTests()
                 .Provide(options)
-                .ConfigureParameters(a => a.Add("Q", $"{level},{x},{y}"))
+                .ConfigureParameterQ(level, x, y)
                 .Build();
 
             var data = _fixture.CreateMany<byte>(10);
             var result = new MemoryStream(data.ToArray());
             var outputStream = new MemoryStream();
 
-            container.Resolve<HttpResponseBase>().Configure().OutputStream.Returns(outputStream);
+            container.Resolve<IResponse>().Configure().OutputStream.Returns(outputStream);
             container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, "dsstoast.plate", level, x, y).Returns(result);
 
             // Act
             container.RunProviderTest<DSSToastProvider>();
 
             // Assert
-            Assert.Equal("image/png", container.Resolve<HttpResponseBase>().ContentType);
+            Assert.Equal("image/png", container.Resolve<IResponse>().ContentType);
             Assert.Equal(data, outputStream.ToArray());
         }
 
@@ -80,7 +80,7 @@ namespace WWT.Providers.Tests
             using var container = AutoSubstitute.Configure()
                 .InitializeProviderTests()
                 .Provide(options)
-                .ConfigureParameters(a => a.Add("Q", $"{level},{x},{y}"))
+                .ConfigureParameterQ(level, x, y)
                 .Build();
 
             var data = _fixture.CreateMany<byte>(10);
@@ -88,14 +88,14 @@ namespace WWT.Providers.Tests
             var outputStream = new MemoryStream();
             var filename = $"DSSpngL5to12_x{fileX}_y{fileY}.plate";
 
-            container.Resolve<HttpResponseBase>().Configure().OutputStream.Returns(outputStream);
+            container.Resolve<IResponse>().Configure().OutputStream.Returns(outputStream);
             container.Resolve<IPlateTilePyramid>().GetStream(options.DssToastPng, filename, level2, x2, y2).Returns(result);
 
             // Act
             container.RunProviderTest<DSSToastProvider>();
 
             // Assert
-            Assert.Equal("image/png", container.Resolve<HttpResponseBase>().ContentType);
+            Assert.Equal("image/png", container.Resolve<IResponse>().ContentType);
             Assert.Equal(data, outputStream.ToArray());
         }
     }

--- a/tests/WWT.Providers.Tests/DemMarsNewProviderTests.cs
+++ b/tests/WWT.Providers.Tests/DemMarsNewProviderTests.cs
@@ -73,8 +73,8 @@ namespace WWT.Providers.Tests
 
             // Assert
             container.Resolve<IPlateTilePyramid>().Received(1).GetStream(Prefix, $"marsToastDem_{hash}.plate", -1, level, x, y);
-            container.Resolve<HttpResponseBase>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<HttpResponseBase>().ContentType);
+            container.Resolve<IResponse>().Received(1).Write("No image");
+            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
         }
     }
 }

--- a/tests/WWT.Providers.Tests/DemMarsProviderTests.cs
+++ b/tests/WWT.Providers.Tests/DemMarsProviderTests.cs
@@ -72,8 +72,8 @@ namespace WWT.Providers.Tests
 
             // Assert
             container.Resolve<IPlateTilePyramid>().Received(1).GetStream(Prefix, PlateName, -1, level, x, y);
-            container.Resolve<HttpResponseBase>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<HttpResponseBase>().ContentType);
+            container.Resolve<IResponse>().Received(1).Write("No image");
+            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
         }
     }
 }

--- a/tests/WWT.Providers.Tests/DustToastProviderTests.cs
+++ b/tests/WWT.Providers.Tests/DustToastProviderTests.cs
@@ -26,14 +26,14 @@ namespace WWT.Providers.Tests
             // Arrange
             using var container = AutoSubstitute.Configure()
                 .InitializeProviderTests()
-                .ConfigureParameters(a => a.Add("Q", $"{level},2,3"))
+                .ConfigureParameterQ(level, 2, 3)
                 .Build();
 
             // Act
             container.RunProviderTest<DustToastProvider>();
 
             // Assert
-            Assert.Empty(container.Resolve<HttpResponseBase>().ContentType);
+            Assert.Empty(container.Resolve<IResponse>().ContentType);
         }
 
         [Theory]
@@ -49,7 +49,7 @@ namespace WWT.Providers.Tests
             using var container = AutoSubstitute.Configure()
                 .InitializeProviderTests()
                 .Provide(options)
-                .ConfigureParameters(a => a.Add("Q", $"{level},{x},{y}"))
+                .ConfigureParameterQ(level, x, y)
                 .Build();
 
             var data = _fixture.CreateMany<byte>(10);
@@ -60,7 +60,7 @@ namespace WWT.Providers.Tests
             container.RunProviderTest<DustToastProvider>();
 
             // Assert
-            Assert.Equal("image/png", container.Resolve<HttpResponseBase>().ContentType);
+            Assert.Equal("image/png", container.Resolve<IResponse>().ContentType);
             Assert.Equal(data, container.GetOutputData());
         }
     }

--- a/tests/WWT.Providers.Tests/Galex4FarProviderTests.cs
+++ b/tests/WWT.Providers.Tests/Galex4FarProviderTests.cs
@@ -102,8 +102,8 @@ namespace WWT.Providers.Tests
 
             // Assert
             container.Resolve<IPlateTilePyramid>().Received(1).GetStream(options.WwtTilesDir, plateName, passedLevel, x, y);
-            container.Resolve<HttpResponseBase>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<HttpResponseBase>().ContentType);
+            container.Resolve<IResponse>().Received(1).Write("No image");
+            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
         }
 
         [InlineData(false)]
@@ -138,8 +138,8 @@ namespace WWT.Providers.Tests
             container.RunProviderTest<Galex4FarProvider>();
 
             // Assert
-            container.Resolve<HttpResponseBase>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<HttpResponseBase>().ContentType);
+            container.Resolve<IResponse>().Received(1).Write("No image");
+            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
         }
 
         [InlineData(11)]
@@ -161,8 +161,8 @@ namespace WWT.Providers.Tests
             container.RunProviderTest<Galex4FarProvider>();
 
             // Assert
-            container.Resolve<HttpResponseBase>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<HttpResponseBase>().ContentType);
+            container.Resolve<IResponse>().Received(1).Write("No image");
+            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
         }
     }
 }

--- a/tests/WWT.Providers.Tests/Galex4NearProviderTests.cs
+++ b/tests/WWT.Providers.Tests/Galex4NearProviderTests.cs
@@ -102,8 +102,8 @@ namespace WWT.Providers.Tests
 
             // Assert
             container.Resolve<IPlateTilePyramid>().Received(1).GetStream(options.WwtTilesDir, plateName, passedLevel, x, y);
-            container.Resolve<HttpResponseBase>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<HttpResponseBase>().ContentType);
+            container.Resolve<IResponse>().Received(1).Write("No image");
+            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
         }
 
         [InlineData(false)]
@@ -138,8 +138,8 @@ namespace WWT.Providers.Tests
             container.RunProviderTest<Galex4NearProvider>();
 
             // Assert
-            container.Resolve<HttpResponseBase>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<HttpResponseBase>().ContentType);
+            container.Resolve<IResponse>().Received(1).Write("No image");
+            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
         }
 
         [InlineData(11)]
@@ -161,8 +161,8 @@ namespace WWT.Providers.Tests
             container.RunProviderTest<Galex4NearProvider>();
 
             // Assert
-            container.Resolve<HttpResponseBase>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<HttpResponseBase>().ContentType);
+            container.Resolve<IResponse>().Received(1).Write("No image");
+            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
         }
     }
 }

--- a/tests/WWT.Providers.Tests/GalexToastProviderTests.cs
+++ b/tests/WWT.Providers.Tests/GalexToastProviderTests.cs
@@ -103,8 +103,8 @@ namespace WWT.Providers.Tests
 
             // Assert
             container.Resolve<IPlateTilePyramid>().Received(1).GetStream(prefix, plateName, passedLevel, x, y);
-            container.Resolve<HttpResponseBase>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<HttpResponseBase>().ContentType);
+            container.Resolve<IResponse>().Received(1).Write("No image");
+            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
         }
 
         [InlineData(false)]
@@ -139,8 +139,8 @@ namespace WWT.Providers.Tests
             container.RunProviderTest<GalexToastProvider>();
 
             // Assert
-            container.Resolve<HttpResponseBase>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<HttpResponseBase>().ContentType);
+            container.Resolve<IResponse>().Received(1).Write("No image");
+            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
         }
 
         [InlineData(11)]
@@ -162,8 +162,8 @@ namespace WWT.Providers.Tests
             container.RunProviderTest<GalexToastProvider>();
 
             // Assert
-            container.Resolve<HttpResponseBase>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<HttpResponseBase>().ContentType);
+            container.Resolve<IResponse>().Received(1).Write("No image");
+            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
         }
     }
 }

--- a/tests/WWT.Providers.Tests/g360ProviderTests.cs
+++ b/tests/WWT.Providers.Tests/g360ProviderTests.cs
@@ -84,8 +84,8 @@ namespace WWT.Providers.Tests
             container.RunProviderTest<g360Provider>();
 
             // Assert
-            container.Resolve<HttpResponseBase>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<HttpResponseBase>().ContentType);
+            container.Resolve<IResponse>().Received(1).Write("No image");
+            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
         }
 
         [InlineData(13)]
@@ -107,8 +107,8 @@ namespace WWT.Providers.Tests
             container.RunProviderTest<g360Provider>();
 
             // Assert
-            container.Resolve<HttpResponseBase>().DidNotReceiveWithAnyArgs().Write(Arg.Any<string>());
-            Assert.Empty(container.Resolve<HttpResponseBase>().ContentType);
+            container.Resolve<IResponse>().DidNotReceiveWithAnyArgs().Write(Arg.Any<string>());
+            Assert.Empty(container.Resolve<IResponse>().ContentType);
         }
     }
 }


### PR DESCRIPTION
A while back, we swapped out a struct implementaiton of WwtContext with
an interface. At that time, Http*Base types were used as abstractions
over the request/response objects. These are possible to mock, but not
as easy as interfaces. This change swaps these out for pure interfaces
so that mocking is much easier and as a plus removes some dependency on
System.Web.

An implementation of this for Page is still used for the aspx pages.
However, that implementation implements all the interfaces (explicity,
ie privately) so that only a single object must be constructed to pass
the context around.