### PR TITLE
Add a test harness for providers to build on top of

### DIFF
--- a/src/WWT.Providers/Providers/GalexToastProvider.cs
+++ b/src/WWT.Providers/Providers/GalexToastProvider.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Configuration;
-using System.IO;
 using WWTWebservices;
 
 namespace WWT.Providers

--- a/tests/WWT.Providers.Tests/DSSTests.cs
+++ b/tests/WWT.Providers.Tests/DSSTests.cs
@@ -1,102 +1,45 @@
-using AutofacContrib.NSubstitute;
-using AutoFixture;
 using NSubstitute;
-using NSubstitute.Extensions;
+using System;
 using System.IO;
-using System.Linq;
-using System.Web;
 using WWTWebservices;
-using Xunit;
 
 namespace WWT.Providers.Tests
 {
-    public class DSSTests
+    public class DSSTests : ProviderTests<DSSProvider>
     {
-        private readonly Fixture _fixture;
+        protected override int MaxLevel => 12;
 
-        public DSSTests()
+        protected override Action<IResponse> StreamExceptionResponseHandler => null;
+
+        protected override Action<IResponse> NullStreamResponseHandler => null;
+
+        protected override Stream GetStreamFromPlateTilePyramid(IPlateTilePyramid plateTiles, int level, int x, int y)
         {
-            _fixture = new Fixture();
+            if (level > 12)
+            {
+                return null;
+            }
+            else if (level < 8)
+            {
+                return plateTiles.GetStream(Options.WwtTilesDir, "dssterrapixel.plate", level, x, y);
+            }
+            else
+            {
+                var powLev5Diff = (int)Math.Pow(2, level - 5);
+                var X32 = x / powLev5Diff;
+                var Y32 = y / powLev5Diff;
+
+                var L5 = level - 5;
+                var X5 = x % powLev5Diff;
+                var Y5 = y % powLev5Diff;
+
+                return plateTiles.GetStream(Options.DssTerapixelDir, $"DSSpngL5to12_x{X32}_y{Y32}.plate", L5, X5, Y5);
+            }
         }
 
-        [Theory]
-        [InlineData(13)]
-        public void TooLarge(int level)
+        protected override void ExpectedResponseAboveMaxLevel(IResponse response)
         {
-            // Arrange
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .ConfigureParameterQ(level, 2, 3)
-                .Build();
-
-            // Act
-            container.RunProviderTest<DSSProvider>();
-
-            // Assert
-            container.Resolve<IResponse>().Received(1).Write("No image");
-        }
-
-        [Theory]
-        [InlineData(7)]
-        [InlineData(0)]
-        public void LowLevels(int level)
-        {
-            // Arrange
-            var x = _fixture.Create<int>();
-            var y = _fixture.Create<int>();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .Provide(options)
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            var data = _fixture.CreateMany<byte>(10);
-            var result = new MemoryStream(data.ToArray());
-            var outputStream = new MemoryStream();
-
-            container.Resolve<IResponse>().Configure().OutputStream.Returns(outputStream);
-            container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, "dssterrapixel.plate", level, x, y).Returns(result);
-
-            // Act
-            container.RunProviderTest<DSSProvider>();
-
-            // Assert
-            Assert.Equal("image/png", container.Resolve<IResponse>().ContentType);
-            Assert.Equal(data, outputStream.ToArray());
-        }
-
-        [Theory]
-        [InlineData(8, 1, 2, 0, 0, 3, 1, 2)]
-        [InlineData(9, 3, 3, 0, 0, 4, 3, 3)]
-        [InlineData(10, 6, 3, 0, 0, 5, 6, 3)]
-        [InlineData(11, 1, 3, 0, 0, 6, 1, 3)]
-        public void HighLevels(int level, int x, int y, int fileX, int fileY, int level2, int x2, int y2)
-        {
-            // Arrange
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .Provide(options)
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            var data = _fixture.CreateMany<byte>(10);
-            var result = new MemoryStream(data.ToArray());
-            var outputStream = new MemoryStream();
-            var filename = $"DSSpngL5to12_x{fileX}_y{fileY}.plate";
-
-            container.Resolve<IResponse>().Configure().OutputStream.Returns(outputStream);
-            container.Resolve<IPlateTilePyramid>().GetStream(options.DssTerapixelDir, filename, level2, x2, y2).Returns(result);
-
-            // Act
-            container.RunProviderTest<DSSProvider>();
-
-            // Assert
-            Assert.Equal("image/png", container.Resolve<IResponse>().ContentType);
-            Assert.Equal(data, outputStream.ToArray());
+            response.Received(1).Write("No image");
         }
     }
 }

--- a/tests/WWT.Providers.Tests/DemMarsNewProviderTests.cs
+++ b/tests/WWT.Providers.Tests/DemMarsNewProviderTests.cs
@@ -1,80 +1,27 @@
-﻿using AutofacContrib.NSubstitute;
-using AutoFixture;
-using NSubstitute;
-using NSubstitute.Extensions;
+﻿using Castle.DynamicProxy.Contributors;
+using System;
 using System.IO;
-using System.Linq;
-using System.Web;
 using WWTWebservices;
 using Xunit;
 
 namespace WWT.Providers.Tests
 {
-    public class DemMarsNewProviderTests
+    public class DemMarsNewProviderTests : ProviderTests<DemMarsNewProvider>
     {
-        private const string Prefix = @"\\wwt-mars\marsroot\dem\";
+        protected override int MaxLevel => 17;
 
-        private readonly Fixture _fixture;
+        protected override Action<IResponse> StreamExceptionResponseHandler => null;
 
-        public DemMarsNewProviderTests()
+        protected override void ExpectedResponseAboveMaxLevel(IResponse response)
         {
-            _fixture = new Fixture();
+            Assert.Empty(response.OutputStream.ToArray());
         }
 
-        [InlineData(0, 0, 0)]
-        [Theory]
-        public void ExpectedTests(int level, int x, int y)
+        protected override Stream GetStreamFromPlateTilePyramid(IPlateTilePyramid plateTiles, int level, int x, int y)
         {
-            // Arrange
-            var data = _fixture.CreateMany<byte>().ToArray();
-            var hash = DirectoryEntry.ComputeHash(level + 128, x, y) % 400;
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-            container.Resolve<IPlateTilePyramid>().GetStream(Prefix, $"marsToastDem_{hash}.plate", -1, level, x, y).Returns(new MemoryStream(data));
+            var index = DirectoryEntry.ComputeHash(level + 128, x, y) % 400;
 
-            // Act
-            container.RunProviderTest<DemMarsNewProvider>();
-
-            // Assert
-            container.Resolve<IPlateTilePyramid>().Received(1).GetStream(Prefix, $"marsToastDem_{hash}.plate", -1, level, x, y);
-            Assert.Equal(data, container.GetOutputData());
-        }
-
-        [InlineData(false)]
-        [InlineData(true)]
-        [Theory]
-        public void EmptyResult(bool isNull)
-        {
-            // Arrange
-            var level = _fixture.Create<int>() % 18;
-            var x = _fixture.Create<int>();
-            var y = _fixture.Create<int>();
-            var hash = DirectoryEntry.ComputeHash(level + 128, x, y) % 400;
-
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            if (isNull)
-            {
-                container.Resolve<IPlateTilePyramid>().GetStream(Prefix, $"marsToastDem_{hash}.plate", -1, level, x, y).Returns((Stream)null);
-            }
-            {
-                var empty = Substitute.ForPartsOf<Stream>();
-                empty.Configure().Length.Returns(0);
-                container.Resolve<IPlateTilePyramid>().GetStream(Prefix, $"marsToastDem_{hash}.plate", -1, level, x, y).Returns(empty);
-            }
-
-            // Act
-            container.RunProviderTest<DemMarsNewProvider>();
-
-            // Assert
-            container.Resolve<IPlateTilePyramid>().Received(1).GetStream(Prefix, $"marsToastDem_{hash}.plate", -1, level, x, y);
-            container.Resolve<IResponse>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
+            return plateTiles.GetStream(@"\\wwt-mars\marsroot\dem\", $"marsToastDem_{index}.plate", -1, level, x, y);
         }
     }
 }

--- a/tests/WWT.Providers.Tests/DustToastProviderTests.cs
+++ b/tests/WWT.Providers.Tests/DustToastProviderTests.cs
@@ -1,67 +1,27 @@
-﻿using AutofacContrib.NSubstitute;
-using AutoFixture;
-using NSubstitute;
-using NSubstitute.Extensions;
+﻿using System;
 using System.IO;
-using System.Linq;
-using System.Web;
 using WWTWebservices;
 using Xunit;
 
 namespace WWT.Providers.Tests
 {
-    public class DustToastProviderTests
+    public class DustToastProviderTests : ProviderTests<DustToastProvider>
     {
-        private readonly Fixture _fixture;
+        protected override Action<IResponse> StreamExceptionResponseHandler => null;
 
-        public DustToastProviderTests()
+        protected override Action<IResponse> NullStreamResponseHandler => null;
+
+        protected override int MaxLevel => 7;
+
+        protected override void ExpectedResponseAboveMaxLevel(IResponse response)
         {
-            _fixture = new Fixture();
+            Assert.Empty(response.OutputStream.ToArray());
         }
 
-        [Theory]
-        [InlineData(8)]
-        public void TooLarge(int level)
+        protected override Stream GetStreamFromPlateTilePyramid(IPlateTilePyramid plateTiles, int level, int x, int y)
         {
-            // Arrange
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .ConfigureParameterQ(level, 2, 3)
-                .Build();
-
-            // Act
-            container.RunProviderTest<DustToastProvider>();
-
-            // Assert
-            Assert.Empty(container.Resolve<IResponse>().ContentType);
-        }
-
-        [Theory]
-        [InlineData(7)]
-        [InlineData(0)]
-        public void LowLevels(int level)
-        {
-            // Arrange
-            var x = _fixture.Create<int>();
-            var y = _fixture.Create<int>();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .Provide(options)
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            var data = _fixture.CreateMany<byte>(10);
-
-            container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, "dust.plate", level, x, y).Returns(new MemoryStream(data.ToArray()));
-
-            // Act
-            container.RunProviderTest<DustToastProvider>();
-
-            // Assert
-            Assert.Equal("image/png", container.Resolve<IResponse>().ContentType);
-            Assert.Equal(data, container.GetOutputData());
+            return plateTiles.GetStream(Options.WwtTilesDir, "dust.plate", level, x, y);
         }
     }
 }
+

--- a/tests/WWT.Providers.Tests/Galex4FarProviderTests.cs
+++ b/tests/WWT.Providers.Tests/Galex4FarProviderTests.cs
@@ -1,168 +1,31 @@
-﻿using AutofacContrib.NSubstitute;
-using AutoFixture;
-using NSubstitute;
-using NSubstitute.Extensions;
-using System;
+﻿using System;
 using System.IO;
-using System.Linq;
-using System.Web;
 using WWTWebservices;
-using Xunit;
 
 namespace WWT.Providers.Tests
 {
-    public class Galex4FarProviderTests
+    public class Galex4FarProviderTests : ProviderTests<Galex4FarProvider>
     {
-        private const string PlateName = "Galex4Far_L0to8_x0_y0.plate";
+        protected override int MaxLevel => 10;
 
-        private readonly Fixture _fixture;
-
-        public Galex4FarProviderTests()
+        protected override Stream GetStreamFromPlateTilePyramid(IPlateTilePyramid plateTiles, int level, int x, int y)
         {
-            _fixture = new Fixture();
-        }
-
-        [InlineData(0, 0, 0)]
-        [InlineData(8, 0, 0)]
-        [Theory]
-        public void ExpectedTests(int level, int x, int y)
-        {
-            // Arrange
-            var data = _fixture.CreateMany<byte>().ToArray();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .Provide(options)
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, PlateName, level, x, y).Returns(new MemoryStream(data));
-
-            // Act
-            container.RunProviderTest<Galex4FarProvider>();
-
-            // Assert
-            container.Resolve<IPlateTilePyramid>().Received(1).GetStream(options.WwtTilesDir, PlateName, level, x, y);
-            Assert.Equal(data, container.GetOutputData());
-        }
-
-
-        [InlineData(9, 0, 0)]
-        [Theory]
-        public void ExpectedTestsLevel9(int level, int x, int y)
-        {
-            // Arrange
-            var powLev3Diff = (int)Math.Pow(2, level - 3);
-            var X8 = x / powLev3Diff;
-            var Y8 = y / powLev3Diff;
-            var L3 = level - 3;
-            var X3 = x % powLev3Diff;
-            var Y3 = y % powLev3Diff;
-            var plateName = $"Galex4Far_L3to10_x{X8}_y{Y8}.plate";
-            var data = _fixture.CreateMany<byte>().ToArray();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .Provide(options)
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, plateName, L3, X3, Y3).Returns(new MemoryStream(data));
-
-            // Act
-            container.RunProviderTest<Galex4FarProvider>();
-
-            // Assert
-            container.Resolve<IPlateTilePyramid>().Received(1).GetStream(options.WwtTilesDir, plateName, L3, X3, Y3);
-            Assert.Equal(data, container.GetOutputData());
-        }
-
-        [InlineData(0, 0, 0, 0, PlateName)]
-        [InlineData(8, 0, 0, 8, PlateName)]
-        [InlineData(9, 0, 0, 6, "Galex4Far_L3to10_x0_y0.plate")]
-        [Theory]
-        public void ErrorInStream(int level, int x, int y, int passedLevel, string plateName)
-        {
-            // Arrange
-            var data = _fixture.CreateMany<byte>().ToArray();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .Provide(options)
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, plateName, passedLevel, x, y).Returns(_ => throw new InvalidOperationException());
-
-            // Act
-            container.RunProviderTest<Galex4FarProvider>();
-
-            // Assert
-            container.Resolve<IPlateTilePyramid>().Received(1).GetStream(options.WwtTilesDir, plateName, passedLevel, x, y);
-            container.Resolve<IResponse>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
-        }
-
-        [InlineData(false)]
-        [InlineData(true)]
-        [Theory]
-        public void EmptyResult(bool isNull)
-        {
-            // Arrange
-            var level = _fixture.Create<int>() % 12; // Level must be < 12;
-            var x = _fixture.Create<int>();
-            var y = _fixture.Create<int>();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .Provide(options)
-                .InitializeProviderTests()
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            if (isNull)
+            if (level == 9 || level == 10)
             {
-                container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, PlateName, -1, level, x, y).Returns((Stream)null);
-            }
-            else
-            {
-                var empty = Substitute.ForPartsOf<Stream>();
-                empty.Configure().Length.Returns(0);
-                container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, PlateName, -1, level, x, y).Returns(empty);
+                var powLev3Diff = (int)Math.Pow(2, level - 3);
+                var X8 = x / powLev3Diff;
+                var Y8 = y / powLev3Diff;
+
+                var L3 = level - 3;
+                var X3 = x % powLev3Diff;
+                var Y3 = y % powLev3Diff;
+
+                var plateName = $"Galex4Far_L3to10_x{X8}_y{Y8}.plate";
+
+                return plateTiles.GetStream(Options.WwtTilesDir, plateName, L3, X3, Y3);
             }
 
-            // Act
-            container.RunProviderTest<Galex4FarProvider>();
-
-            // Assert
-            container.Resolve<IResponse>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
-        }
-
-        [InlineData(11)]
-        [Theory]
-        public void LevelTooHigh(int level)
-        {
-            // Arrange
-            var x = _fixture.Create<int>();
-            var y = _fixture.Create<int>();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .Provide(options)
-                .InitializeProviderTests()
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            // Act
-            container.RunProviderTest<Galex4FarProvider>();
-
-            // Assert
-            container.Resolve<IResponse>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
+            return plateTiles.GetStream(Options.WwtTilesDir, "Galex4Far_L0to8_x0_y0.plate", level, x, y);
         }
     }
 }

--- a/tests/WWT.Providers.Tests/Galex4NearProviderTests.cs
+++ b/tests/WWT.Providers.Tests/Galex4NearProviderTests.cs
@@ -1,168 +1,30 @@
-﻿using AutofacContrib.NSubstitute;
-using AutoFixture;
-using NSubstitute;
-using NSubstitute.Extensions;
-using System;
+﻿using System;
 using System.IO;
-using System.Linq;
-using System.Web;
 using WWTWebservices;
-using Xunit;
 
 namespace WWT.Providers.Tests
 {
-    public class Galex4NearProviderTests
+    public class Galex4NearProviderTests : ProviderTests<Galex4NearProvider>
     {
-        private const string PlateName = "Galex4Near_L0to8_x0_y0.plate";
+        protected override int MaxLevel => 10;
 
-        private readonly Fixture _fixture;
-
-        public Galex4NearProviderTests()
+        protected override Stream GetStreamFromPlateTilePyramid(IPlateTilePyramid plateTiles, int level, int x, int y)
         {
-            _fixture = new Fixture();
-        }
-
-        [InlineData(0, 0, 0)]
-        [Theory]
-        public void ExpectedTests(int level, int x, int y)
-        {
-            // Arrange
-            var data = _fixture.CreateMany<byte>().ToArray();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .Provide(options)
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, PlateName, level, x, y).Returns(new MemoryStream(data));
-
-            // Act
-            container.RunProviderTest<Galex4NearProvider>();
-
-            // Assert
-            container.Resolve<IPlateTilePyramid>().Received(1).GetStream(options.WwtTilesDir, PlateName, level, x, y);
-            Assert.Equal(data, container.GetOutputData());
-        }
-
-        [InlineData(9, 0, 0)]
-        [Theory]
-        public void ExpectedTestsLevel9(int level, int x, int y)
-        {
-            // Arrange
-            int powLev3Diff = (int)Math.Pow(2, level - 3);
-            int X8 = y / powLev3Diff;
-            int Y8 = x / powLev3Diff;
-            var plateName = $"Galex4Near_L3to10_x{X8}_y{Y8}.plate";
-
-            int L3 = level - 3;
-            int X3 = x % powLev3Diff;
-            int Y3 = y % powLev3Diff;
-
-            var data = _fixture.CreateMany<byte>().ToArray();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .Provide(options)
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, plateName, L3, X3, Y3).Returns(new MemoryStream(data));
-
-            // Act
-            container.RunProviderTest<Galex4NearProvider>();
-
-            // Assert
-            container.Resolve<IPlateTilePyramid>().Received(1).GetStream(options.WwtTilesDir, plateName, L3, X3, Y3);
-            Assert.Equal(data, container.GetOutputData());
-        }
-
-        [InlineData(0, 0, 0, 0, PlateName)]
-        [InlineData(8, 0, 0, 8, PlateName)]
-        [InlineData(9, 0, 0, 6, "Galex4Near_L3to10_x0_y0.plate")]
-        [Theory]
-        public void ErrorInStream(int level, int x, int y, int passedLevel, string plateName)
-        {
-            // Arrange
-            var data = _fixture.CreateMany<byte>().ToArray();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .Provide(options)
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, plateName, passedLevel, x, y).Returns(_ => throw new InvalidOperationException());
-
-            // Act
-            container.RunProviderTest<Galex4NearProvider>();
-
-            // Assert
-            container.Resolve<IPlateTilePyramid>().Received(1).GetStream(options.WwtTilesDir, plateName, passedLevel, x, y);
-            container.Resolve<IResponse>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
-        }
-
-        [InlineData(false)]
-        [InlineData(true)]
-        [Theory]
-        public void EmptyResult(bool isNull)
-        {
-            // Arrange
-            var level = _fixture.Create<int>() % 12; // Level must be < 12;
-            var x = _fixture.Create<int>();
-            var y = _fixture.Create<int>();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .Provide(options)
-                .InitializeProviderTests()
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            if (isNull)
+            if (level == 9 || level == 10)
             {
-                container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, PlateName, -1, level, x, y).Returns((Stream)null);
-            }
-            else
-            {
-                var empty = Substitute.ForPartsOf<Stream>();
-                empty.Configure().Length.Returns(0);
-                container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, PlateName, -1, level, x, y).Returns(empty);
+                var powLev3Diff = (int)Math.Pow(2, level - 3);
+                var X8 = x / powLev3Diff;
+                var Y8 = y / powLev3Diff;
+                var plateName = $"Galex4Near_L3to10_x{X8}_y{Y8}.plate";
+
+                var L3 = level - 3;
+                var X3 = x % powLev3Diff;
+                var Y3 = y % powLev3Diff;
+
+                return plateTiles.GetStream(Options.WwtTilesDir, plateName, L3, X3, Y3);
             }
 
-            // Act
-            container.RunProviderTest<Galex4NearProvider>();
-
-            // Assert
-            container.Resolve<IResponse>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
-        }
-
-        [InlineData(11)]
-        [Theory]
-        public void LevelTooHigh(int level)
-        {
-            // Arrange
-            var x = _fixture.Create<int>();
-            var y = _fixture.Create<int>();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .Provide(options)
-                .InitializeProviderTests()
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            // Act
-            container.RunProviderTest<Galex4NearProvider>();
-
-            // Assert
-            container.Resolve<IResponse>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
+            return plateTiles.GetStream(Options.WwtTilesDir, "Galex4Near_L0to8_x0_y0.plate", level, x, y);
         }
     }
 }

--- a/tests/WWT.Providers.Tests/GalexToastProviderTests.cs
+++ b/tests/WWT.Providers.Tests/GalexToastProviderTests.cs
@@ -1,169 +1,33 @@
-﻿using AutofacContrib.NSubstitute;
-using AutoFixture;
-using NSubstitute;
-using NSubstitute.Extensions;
-using System;
+﻿using System;
 using System.IO;
-using System.Linq;
-using System.Web;
 using WWTWebservices;
-using Xunit;
 
 namespace WWT.Providers.Tests
 {
-    public class GalexToastProviderTests
+    public class GalexToastProviderTests : ProviderTests<GalexToastProvider>
     {
-        private const string PlateName = "GalexBoth_L0to8_x0_y0.plate";
+        protected override int MaxLevel => 10;
 
-        private readonly Fixture _fixture;
-
-        public GalexToastProviderTests()
+        protected override Stream GetStreamFromPlateTilePyramid(IPlateTilePyramid plateTiles, int level, int x, int y)
         {
-            _fixture = new Fixture();
-        }
-
-        [InlineData(0, 0, 0)]
-        [Theory]
-        public void ExpectedTests(int level, int x, int y)
-        {
-            // Arrange
-            var data = _fixture.CreateMany<byte>().ToArray();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .Provide(options)
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, PlateName, level, x, y).Returns(new MemoryStream(data));
-
-            // Act
-            container.RunProviderTest<GalexToastProvider>();
-
-            // Assert
-            container.Resolve<IPlateTilePyramid>().Received(1).GetStream(options.WwtTilesDir, PlateName, level, x, y);
-            Assert.Equal(data, container.GetOutputData());
-        }
-
-        [InlineData(9, 0, 0)]
-        [Theory]
-        public void ExpectedTestsLevel9(int level, int x, int y)
-        {
-            // Arrange
-            int powLev3Diff = (int)Math.Pow(2, level - 3);
-            int X8 = y / powLev3Diff;
-            int Y8 = x / powLev3Diff;
-            var plateName = $"GalexBoth_L3to10_x{X8}_y{Y8}.plate";
-
-            int L3 = level - 3;
-            int X3 = x % powLev3Diff;
-            int Y3 = y % powLev3Diff;
-
-            var data = _fixture.CreateMany<byte>().ToArray();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .Provide(options)
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            container.Resolve<IPlateTilePyramid>().GetStream(options.WwtGalexDir, plateName, L3, X3, Y3).Returns(new MemoryStream(data));
-
-            // Act
-            container.RunProviderTest<GalexToastProvider>();
-
-            // Assert
-            container.Resolve<IPlateTilePyramid>().Received(1).GetStream(options.WwtGalexDir, plateName, L3, X3, Y3);
-            Assert.Equal(data, container.GetOutputData());
-        }
-
-        [InlineData(0, 0, 0, 0, PlateName)]
-        [InlineData(8, 0, 0, 8, PlateName)]
-        [InlineData(9, 0, 0, 6, "GalexBoth_L3to10_x0_y0.plate")]
-        [Theory]
-        public void ErrorInStream(int level, int x, int y, int passedLevel, string plateName)
-        {
-            // Arrange
-            var data = _fixture.CreateMany<byte>().ToArray();
-            var options = _fixture.Create<FilePathOptions>();
-            var prefix = level == 9 ? options.WwtGalexDir : options.WwtTilesDir;
-
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .Provide(options)
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            container.Resolve<IPlateTilePyramid>().GetStream(prefix, plateName, passedLevel, x, y).Returns(_ => throw new InvalidOperationException());
-
-            // Act
-            container.RunProviderTest<GalexToastProvider>();
-
-            // Assert
-            container.Resolve<IPlateTilePyramid>().Received(1).GetStream(prefix, plateName, passedLevel, x, y);
-            container.Resolve<IResponse>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
-        }
-
-        [InlineData(false)]
-        [InlineData(true)]
-        [Theory]
-        public void EmptyResult(bool isNull)
-        {
-            // Arrange
-            var level = _fixture.Create<int>() % 12; // Level must be < 12;
-            var x = _fixture.Create<int>();
-            var y = _fixture.Create<int>();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .Provide(options)
-                .InitializeProviderTests()
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            if (isNull)
+            if (level == 9 || level == 10)
             {
-                container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, PlateName, -1, level, x, y).Returns((Stream)null);
+                int powLev3Diff = (int)Math.Pow(2, level - 3);
+                int X8 = x / powLev3Diff;
+                int Y8 = y / powLev3Diff;
+
+                int L3 = level - 3;
+                int X3 = x % powLev3Diff;
+                int Y3 = y % powLev3Diff;
+
+                var plateName = $"GalexBoth_L3to10_x{X8}_y{Y8}.plate";
+
+                return plateTiles.GetStream(Options.WwtGalexDir, plateName, L3, X3, Y3);
             }
             else
             {
-                var empty = Substitute.ForPartsOf<Stream>();
-                empty.Configure().Length.Returns(0);
-                container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, PlateName, -1, level, x, y).Returns(empty);
+                return plateTiles.GetStream(Options.WwtTilesDir, "GalexBoth_L0to8_x0_y0.plate", level, x, y);
             }
-
-            // Act
-            container.RunProviderTest<GalexToastProvider>();
-
-            // Assert
-            container.Resolve<IResponse>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
-        }
-
-        [InlineData(11)]
-        [Theory]
-        public void LevelTooHigh(int level)
-        {
-            // Arrange
-            var x = _fixture.Create<int>();
-            var y = _fixture.Create<int>();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .Provide(options)
-                .InitializeProviderTests()
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            // Act
-            container.RunProviderTest<GalexToastProvider>();
-
-            // Assert
-            container.Resolve<IResponse>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
         }
     }
 }

--- a/tests/WWT.Providers.Tests/HttpAutoSubstituteExtensions.cs
+++ b/tests/WWT.Providers.Tests/HttpAutoSubstituteExtensions.cs
@@ -10,10 +10,16 @@ namespace WWT.Providers.Tests
     internal static class HttpAutoSubstituteExtensions
     {
         public static byte[] GetOutputData(this AutoSubstitute container)
-        {
-            using var ms = new MemoryStream();
+            => container.Resolve<IResponse>().OutputStream.ToArray();
 
-            var stream = container.Resolve<IResponse>().OutputStream;
+        public static byte[] ToArray(this Stream stream)
+        {
+            if (stream is MemoryStream msInput)
+            {
+                return msInput.ToArray();
+            }
+
+            using var ms = new MemoryStream();
 
             stream.Position = 0;
             stream.CopyTo(ms);

--- a/tests/WWT.Providers.Tests/ProviderTests.cs
+++ b/tests/WWT.Providers.Tests/ProviderTests.cs
@@ -1,0 +1,197 @@
+﻿using AutofacContrib.NSubstitute;
+using AutoFixture;
+using NSubstitute;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using WWTWebservices;
+using Xunit;
+
+namespace WWT.Providers.Tests
+{
+    public abstract class ProviderTests<T>
+        where T : RequestProvider
+    {
+        private readonly Fixture _fixture;
+
+        public ProviderTests()
+        {
+            _fixture = new Fixture();
+            Options = _fixture.Create<FilePathOptions>();
+        }
+
+        protected FilePathOptions Options { get; }
+
+        protected abstract int MaxLevel { get; }
+
+        protected virtual Action<IResponse> StreamExceptionResponseHandler { get; } = response =>
+        {
+            response.Received(1).Write("No image");
+            Assert.Equal("text/plain", response.ContentType);
+        };
+
+        protected virtual Action<IResponse> NullStreamResponseHandler { get; } = response =>
+        {
+            response.Received(1).Write("No image");
+            Assert.Equal("text/plain", response.ContentType);
+        };
+
+        protected abstract Stream GetStreamFromPlateTilePyramid(IPlateTilePyramid plateTiles, int level, int x, int y);
+
+        protected virtual void ExpectedResponseAboveMaxLevel(IResponse response)
+        {
+            response.Received(1).Write("No image");
+            Assert.Equal("text/plain", response.ContentType);
+        }
+
+        [Fact]
+        public void ExpectedTests()
+        {
+            for (int level = 0; level < MaxLevel; level++)
+            {
+                // Arrange
+                var data = _fixture.CreateMany<byte>().ToArray();
+                var x = _fixture.Create<int>();
+                var y = _fixture.Create<int>();
+
+                using var container = AutoSubstitute.Configure()
+                    .InitializeProviderTests()
+                    .Provide(Options)
+                    .ConfigureParameterQ(level, x, y)
+                    .Build();
+
+                GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>(), level, x, y).Returns(new MemoryStream(data));
+
+                // Act
+                container.RunProviderTest<T>();
+
+                // Assert
+                GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>().Received(1), level, x, y);
+                Assert.Equal(data, container.GetOutputData());
+            }
+        }
+
+        [Fact]
+        public void ErrorInStream()
+        {
+            foreach (var level in Enumerable.Range(0, MaxLevel))
+            {
+                // Arrange
+                var data = _fixture.CreateMany<byte>().ToArray();
+                var x = _fixture.Create<int>();
+                var y = _fixture.Create<int>();
+
+                using var container = AutoSubstitute.Configure()
+                    .InitializeProviderTests()
+                    .Provide(Options)
+                    .ConfigureParameterQ(level, x, y)
+                    .Build();
+
+                GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>(), level, x, y).Returns(_ => throw new InvalidOperationException());
+
+                if (StreamExceptionResponseHandler is null)
+                {
+                    // Act
+                    Assert.Throws<InvalidOperationException>(() => container.RunProviderTest<T>());
+                }
+                else
+                {
+                    // Act
+                    container.RunProviderTest<T>();
+
+                    // Assert
+                    GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>().Received(1), level, x, y);
+                    StreamExceptionResponseHandler(container.Resolve<IResponse>());
+                }
+            }
+        }
+
+        [Fact]
+        public void EmptyResult()
+        {
+            // Arrange
+            var level = _fixture.Create<int>() % MaxLevel;
+            var x = _fixture.Create<int>();
+            var y = _fixture.Create<int>();
+
+            using var container = AutoSubstitute.Configure()
+                .Provide(Options)
+                .InitializeProviderTests()
+                .ConfigureParameterQ(level, x, y)
+                .Build();
+
+            var empty = new MemoryStream();
+            GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>(), level, x, y).Returns(empty);
+
+            // Act
+            container.RunProviderTest<T>();
+
+            // Assert
+            GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>().Received(1), level, x, y);
+            Assert.Empty(container.GetOutputData());
+        }
+
+        [Fact]
+        public void NullResult()
+        {
+            // Arrange
+            var level = _fixture.Create<int>() % MaxLevel;
+            var x = _fixture.Create<int>();
+            var y = _fixture.Create<int>();
+
+            using var container = AutoSubstitute.Configure()
+                .Provide(Options)
+                .InitializeProviderTests()
+                .ConfigureParameterQ(level, x, y)
+                .Build();
+
+            GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>(), level, x, y).Returns((Stream)null);
+
+            if (NullStreamResponseHandler is null)
+            {
+                Assert.Throws<NullReferenceException>(() => container.RunProviderTest<T>());
+            }
+            else
+            {
+                // Act
+                container.RunProviderTest<T>();
+
+                // Assert
+                GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>().Received(1), level, x, y);
+                NullStreamResponseHandler(container.Resolve<IResponse>());
+            }
+        }
+
+        [Fact]
+        public void AboveMaxLevel()
+        {
+            foreach (var level in GetLevelsAboveMax())
+            {
+                // Arrange
+                var x = _fixture.Create<int>();
+                var y = _fixture.Create<int>();
+
+                using var container = AutoSubstitute.Configure()
+                    .Provide(Options)
+                    .InitializeProviderTests()
+                    .ConfigureParameterQ(level, x, y)
+                    .Build();
+
+                // Act
+                container.RunProviderTest<T>();
+
+                // Assert
+                ExpectedResponseAboveMaxLevel(container.Resolve<IResponse>());
+            }
+
+            IEnumerable<int> GetLevelsAboveMax()
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    yield return MaxLevel + _fixture.Create<int>();
+                }
+            }
+        }
+    }
+}

--- a/tests/WWT.Providers.Tests/g360ProviderTests.cs
+++ b/tests/WWT.Providers.Tests/g360ProviderTests.cs
@@ -1,114 +1,28 @@
-﻿using AutofacContrib.NSubstitute;
-using AutoFixture;
-using NSubstitute;
-using NSubstitute.Extensions;
+﻿using System;
 using System.IO;
-using System.Linq;
-using System.Web;
 using WWTWebservices;
 using Xunit;
 
 namespace WWT.Providers.Tests
 {
-    public class g360ProviderTests
+    public class g360ProviderTests : ProviderTests<g360Provider>
     {
-        private readonly Fixture _fixture;
+        protected override int MaxLevel => 11;
 
-        public g360ProviderTests()
-        {
-            _fixture = new Fixture();
-        }
+        protected override Action<IResponse> StreamExceptionResponseHandler => null;
 
-        private static string GetPlateName(int x, int y, int level)
+        protected override Stream GetStreamFromPlateTilePyramid(IPlateTilePyramid plateTiles, int level, int x, int y)
         {
             var index = DirectoryEntry.ComputeHash(level + 128, x, y) % 16;
 
-            return $"g360-{index}.plate";
+            return plateTiles.GetStream(Options.WwtTilesDir, $"g360-{index}.plate", -1, level, x, y);
         }
 
-        [InlineData(0, 0, 0)]
-        [Theory]
-        public void ExpectedTests(int level, int x, int y)
+        protected override void ExpectedResponseAboveMaxLevel(IResponse response)
         {
-            // Arrange
-            var data = _fixture.CreateMany<byte>().ToArray();
-            var options = _fixture.Create<FilePathOptions>();
-            var plateName = GetPlateName(level, x, y);
-
-            using var container = AutoSubstitute.Configure()
-                .InitializeProviderTests()
-                .Provide(options)
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, plateName, -1, level, x, y).Returns(new MemoryStream(data));
-
-            // Act
-            container.RunProviderTest<g360Provider>();
-
-            // Assert
-            container.Resolve<IPlateTilePyramid>().Received(1).GetStream(options.WwtTilesDir, plateName, -1, level, x, y);
-            Assert.Equal(data, container.GetOutputData());
+            Assert.Empty(response.ContentType);
+            Assert.Empty(response.OutputStream.ToArray());
         }
 
-        [InlineData(false)]
-        [InlineData(true)]
-        [Theory]
-        public void EmptyResult(bool isNull)
-        {
-            // Arrange
-            var level = _fixture.Create<int>() % 12; // Level must be < 12;
-            var x = _fixture.Create<int>();
-            var y = _fixture.Create<int>();
-            var options = _fixture.Create<FilePathOptions>();
-            var plateName = GetPlateName(level, x, y);
-
-            using var container = AutoSubstitute.Configure()
-                .Provide(options)
-                .InitializeProviderTests()
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            if (isNull)
-            {
-                container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, plateName, -1, level, x, y).Returns((Stream)null);
-            }
-            else
-            {
-                var empty = Substitute.ForPartsOf<Stream>();
-                empty.Configure().Length.Returns(0);
-                container.Resolve<IPlateTilePyramid>().GetStream(options.WwtTilesDir, plateName, -1, level, x, y).Returns(empty);
-            }
-
-            // Act
-            container.RunProviderTest<g360Provider>();
-
-            // Assert
-            container.Resolve<IResponse>().Received(1).Write("No image");
-            Assert.Equal("text/plain", container.Resolve<IResponse>().ContentType);
-        }
-
-        [InlineData(13)]
-        [Theory]
-        public void LevelTooHigh(int level)
-        {
-            // Arrange
-            var x = _fixture.Create<int>();
-            var y = _fixture.Create<int>();
-            var options = _fixture.Create<FilePathOptions>();
-
-            using var container = AutoSubstitute.Configure()
-                .Provide(options)
-                .InitializeProviderTests()
-                .ConfigureParameterQ(level, x, y)
-                .Build();
-
-            // Act
-            container.RunProviderTest<g360Provider>();
-
-            // Assert
-            container.Resolve<IResponse>().DidNotReceiveWithAnyArgs().Write(Arg.Any<string>());
-            Assert.Empty(container.Resolve<IResponse>().ContentType);
-        }
-    }
+           }
 }


### PR DESCRIPTION
This will simplify the copy/paste to cover tests. Various methods can be overriden, but the basic tests will be applied for all providers that inherit from this.