### PR TITLE
Separate out GitVersion installation and usage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,14 +13,20 @@ variables:
   buildConfiguration: 'Release'
 
 steps:
-- task: PowerShell@2
-  displayName: 'Update version'
-  name: updateVersion
+
+- task: DotNetCoreCLI@2
+  displayName: 'Install GitVersion'
   inputs:
-    targetType: 'inline'
-    script: |
-      dotnet tool install --global GitVersion.Tool --version 5.1.2      
-      dotnet gitversion /output buildserver /nofetch
+    command: 'custom'
+    custom: 'tool'
+    arguments: 'install --global GitVersion.Tool --version 5.1.2'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Update Version'
+  inputs:
+    command: 'custom'
+    custom: 'gitversion'
+    arguments: '/output buildserver /nofetch'
 
 - task: NuGetToolInstaller@1
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "3.1.402",
+    "rollForward": "minor"
+  }
+}


### PR DESCRIPTION
Seems like there may be a race condition of some sort where a tool is
not available after install sometimes. This will separate out the steps
and should prevent the intermittent failures we've been seeing.