### PR TITLE
Use IPlateTilePyramid in providers starting with t

### DIFF
--- a/src/WWT.Providers/Providers/TileImage.aspx.cs
+++ b/src/WWT.Providers/Providers/TileImage.aspx.cs
@@ -10,55 +10,6 @@ namespace WWT.Providers
 {
     public abstract partial class TileImage : RequestProvider
     {
-        public Bitmap DownloadBitmap(string dataset, int level, int x, int y)
-        {
-            string id = "1738422189";
-            switch (dataset)
-            {
-                case "mars_base_map":
-                    id = "1738422189";
-                    break;
-                case "mars_terrain_color":
-                    id = "220581050";
-                    break;
-                case "mars_hirise":
-                    id = "109459728";
-                    break;
-                case "mars_moc":
-                    id = "252927426";
-                    break;
-                case "mars_historic_green":
-                    id = "1194136815";
-                    break;
-                case "mars_historic_schiaparelli":
-                    id = "1113282550";
-                    break;
-                case "mars_historic_lowell":
-                    id = "675790761";
-                    break;
-                case "mars_historic_antoniadi":
-                    id = "1648157275";
-                    break;
-                case "mars_historic_mec1":
-                    id = "2141096698";
-                    break;
-
-            }
-
-
-            string filename = String.Format("\\wwtcache\\mars\\{3}\\{0}\\{2}\\{1}_{2}.png", level, x, y,
-                id);
-            string path = String.Format("\\wwtcache\\mars\\{3}\\{0}\\{2}", level, x, y, id);
-
-
-            if (!File.Exists(filename))
-            {
-                return null;
-            }
-
-            return new Bitmap(filename);
-        }
-
         public void TileBitmap(Bitmap bmp, string ID)
         {
             string baseDirectory = ConfigurationManager.AppSettings["DSSTileCache"] + "\\imagesTiler\\";

--- a/src/WWT.Providers/Providers/TwoMASSOctProvider.cs
+++ b/src/WWT.Providers/Providers/TwoMASSOctProvider.cs
@@ -7,6 +7,15 @@ namespace WWT.Providers
 {
     public class TwoMASSOctProvider : RequestProvider
     {
+        private readonly IPlateTilePyramid _plateTiles;
+        private readonly FilePathOptions _options;
+
+        public TwoMASSOctProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        {
+            _plateTiles = plateTiles;
+            _options = options;
+        }
+
         public override void Run(IWwtContext context)
         {
             string query = context.Request.Params["Q"];
@@ -14,21 +23,17 @@ namespace WWT.Providers
             int level = Convert.ToInt32(values[0]);
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
-            string file = "2massoctset";
-
-            string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
 
             if (level < 8)
             {
                 context.Response.ContentType = "image/png";
-                Stream s = PlateTilePyramid.GetFileStream(String.Format(wwtTilesDir + "\\{0}.plate", file), level, tileX, tileY);
-                int length = (int)s.Length;
-                byte[] data = new byte[length];
-                s.Read(data, 0, length);
-                context.Response.OutputStream.Write(data, 0, length);
-                context.Response.Flush();
-                context.Response.End();
-                return;
+
+                using (Stream s = _plateTiles.GetStream(_options.WwtTilesDir, "2massoctset.plate", level, tileX, tileY))
+                {
+                    s.CopyTo(context.Response.OutputStream);
+                    context.Response.Flush();
+                    context.Response.End();
+                }
             }
         }
     }

--- a/src/WWT.Providers/Providers/TwoMassToastProvider.cs
+++ b/src/WWT.Providers/Providers/TwoMassToastProvider.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Configuration;
 using System.IO;
 using WWTWebservices;
 
@@ -7,6 +6,15 @@ namespace WWT.Providers
 {
     public class TwoMassToastProvider : RequestProvider
     {
+        private readonly IPlateTilePyramid _plateTiles;
+        private readonly FilePathOptions _options;
+
+        public TwoMassToastProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        {
+            _plateTiles = plateTiles;
+            _options = options;
+        }
+
         public override void Run(IWwtContext context)
         {
             string query = context.Request.Params["Q"];
@@ -14,10 +22,6 @@ namespace WWT.Providers
             int level = Convert.ToInt32(values[0]);
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
-
-            int octsetlevel = level;
-            string filename;
-            string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
 
             if (level > 7)
             {
@@ -27,55 +31,19 @@ namespace WWT.Providers
                 context.Response.End();
                 return;
             }
-
-            if (level < 9)
-            {
-                try
-                {
-                    context.Response.ContentType = "image/png";
-                    Stream s = PlateTilePyramid.GetFileStream(wwtTilesDir + "\\2MassToast0to7.plate", level, tileX, tileY);
-                    int length = (int)s.Length;
-                    byte[] data = new byte[length];
-                    s.Read(data, 0, length);
-                    context.Response.OutputStream.Write(data, 0, length);
-                    context.Response.Flush();
-                    context.Response.End();
-                    return;
-                }
-                catch
-                {
-                    context.Response.Clear();
-                    context.Response.ContentType = "text/plain";
-                    context.Response.Write("No image");
-                    context.Response.End();
-                    return;
-                }
-
-            }
             else
             {
                 try
                 {
-                    int L = level;
-                    int X = tileX;
-                    int Y = tileY;
-                    int powLev3Diff = (int)Math.Pow(2, L - 3);
-                    int X8 = X / powLev3Diff;
-                    int Y8 = Y / powLev3Diff;
-                    filename = string.Format(wwtTilesDir + @"\\Galex4Far_L3to10_x{0}_y{1}.plate", X8, Y8);
-
-                    int L3 = L - 3;
-                    int X3 = X % powLev3Diff;
-                    int Y3 = Y % powLev3Diff;
                     context.Response.ContentType = "image/png";
-                    Stream s = PlateTilePyramid.GetFileStream(filename, L3, X3, Y3);
-                    int length = (int)s.Length;
-                    byte[] data = new byte[length];
-                    s.Read(data, 0, length);
-                    context.Response.OutputStream.Write(data, 0, length);
-                    context.Response.Flush();
-                    context.Response.End();
-                    return;
+
+                    using (Stream s = _plateTiles.GetStream(_options.WwtTilesDir, "2MassToast0to7.plate", level, tileX, tileY))
+                    {
+                        s.CopyTo(context.Response.OutputStream);
+                        context.Response.Flush();
+                        context.Response.End();
+                        return;
+                    }
                 }
                 catch
                 {
@@ -87,10 +55,6 @@ namespace WWT.Providers
                 }
 
             }
-
-            // This file has returns which cause this warning to show in the generated files.
-            // This should be refactored, but that will be a bigger change.
-#pragma warning disable 0162
         }
     }
 }

--- a/src/WWT.Providers/Providers/TychoOctProvider.cs
+++ b/src/WWT.Providers/Providers/TychoOctProvider.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Configuration;
 using System.IO;
 using WWTWebservices;
 
@@ -7,6 +6,15 @@ namespace WWT.Providers
 {
     public class TychoOctProvider : RequestProvider
     {
+        private readonly IPlateTilePyramid _plateTiles;
+        private readonly FilePathOptions _options;
+
+        public TychoOctProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        {
+            _plateTiles = plateTiles;
+            _options = options;
+        }
+
         public override void Run(IWwtContext context)
         {
             string query = context.Request.Params["Q"];
@@ -14,21 +22,17 @@ namespace WWT.Providers
             int level = Convert.ToInt32(values[0]);
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
-            string file = "tychotoast";
-            string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
-
 
             if (level < 8)
             {
                 context.Response.ContentType = "image/png";
-                Stream s = PlateTilePyramid.GetFileStream(String.Format(wwtTilesDir + "\\{0}.plate", file), level, tileX, tileY);
-                int length = (int)s.Length;
-                byte[] data = new byte[length];
-                s.Read(data, 0, length);
-                context.Response.OutputStream.Write(data, 0, length);
-                context.Response.Flush();
-                context.Response.End();
-                return;
+
+                using (Stream s = _plateTiles.GetStream(_options.WwtTilesDir,  $"tychotoast.plate", level, tileX, tileY))
+                {
+                    s.CopyTo(context.Response.OutputStream);
+                    context.Response.Flush();
+                    context.Response.End();
+                }
             }
         }
     }

--- a/src/WWT.Providers/Providers/tiles2Provider.cs
+++ b/src/WWT.Providers/Providers/tiles2Provider.cs
@@ -1,12 +1,20 @@
 using System;
-using System.Configuration;
 using System.IO;
 using WWTWebservices;
 
 namespace WWT.Providers
 {
-    public class tiles2Provider : RequestProvider
+    public class Tiles2Provider : RequestProvider
     {
+        private readonly IPlateTilePyramid _plateTiles;
+        private readonly FilePathOptions _options;
+
+        public Tiles2Provider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        {
+            _plateTiles = plateTiles;
+            _options = options;
+        }
+
         public override void Run(IWwtContext context)
         {
             string query = context.Request.Params["Q"];
@@ -15,36 +23,32 @@ namespace WWT.Providers
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
             string file = values[3];
-            string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
 
             context.Response.AddHeader("Cache-Control", "public, max-age=31536000");
             context.Response.AddHeader("Expires", "Thu, 31 Dec 2009 16:00:00 GMT");
             context.Response.AddHeader("ETag", "155");
             context.Response.AddHeader("Last-Modified", "Tue, 20 May 2008 22:32:37 GMT");
-            //context.Response.AddHeader("Cache-Control", "max-age=36000");
-
 
             if (level < 10)
             {
                 context.Response.ContentType = "image/png";
-                Stream s = PlateFile2.GetFileStream(String.Format(wwtTilesDir + "\\{0}.plate", file), -1, level, tileX, tileY);
-
-                int length = (int)s.Length;
-                if (length == 0)
+                using (Stream s = _plateTiles.GetStream(_options.WwtTilesDir, $"{file}.plate", -1, level, tileX, tileY))
                 {
-
-                    context.Response.Clear();
-                    context.Response.ContentType = "text/plain";
-                    context.Response.Write("No image");
-                    context.Response.End();
-                    return;
+                    if (s.Length == 0)
+                    {
+                        context.Response.Clear();
+                        context.Response.ContentType = "text/plain";
+                        context.Response.Write("No image");
+                        context.Response.End();
+                        return;
+                    }
+                    else
+                    {
+                        s.CopyTo(context.Response.OutputStream);
+                        context.Response.Flush();
+                        context.Response.End();
+                    }
                 }
-                byte[] data = new byte[length];
-                s.Read(data, 0, length);
-                context.Response.OutputStream.Write(data, 0, length);
-                context.Response.Flush();
-                context.Response.End();
-                return;
             }
         }
     }

--- a/src/WWT.Providers/Providers/tilesProvider.cs
+++ b/src/WWT.Providers/Providers/tilesProvider.cs
@@ -1,12 +1,19 @@
 using System;
-using System.Configuration;
 using System.IO;
 using WWTWebservices;
 
 namespace WWT.Providers
 {
-    public class tilesProvider : RequestProvider
+    public class TilesProvider : RequestProvider
     {
+        private readonly IPlateTilePyramid _plateTiles;
+        private readonly FilePathOptions _options;
+
+        public TilesProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        {
+            _plateTiles = plateTiles;
+            _options = options;
+        }
         public override void Run(IWwtContext context)
         {
             string query = context.Request.Params["Q"];
@@ -15,35 +22,33 @@ namespace WWT.Providers
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
             string file = values[3];
-            string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
+            string wwtTilesDir = _options.WwtTilesDir;
 
             context.Response.AddHeader("Cache-Control", "public, max-age=31536000");
             context.Response.AddHeader("Expires", "Thu, 31 Dec 2009 16:00:00 GMT");
             context.Response.AddHeader("ETag", "155");
             context.Response.AddHeader("Last-Modified", "Tue, 20 May 2008 22:32:37 GMT");
-            //context.Response.AddHeader("Cache-Control", "max-age=36000");
-
 
             if (level < 8)
             {
                 context.Response.ContentType = "image/png";
-                Stream s = PlateTilePyramid.GetFileStream(String.Format(wwtTilesDir + "\\{0}.plate", file), level, tileX, tileY);
-                int length = (int)s.Length;
-                if (length == 0)
-                {
 
-                    context.Response.Clear();
-                    context.Response.ContentType = "text/plain";
-                    context.Response.Write("No image");
-                    context.Response.End();
-                    return;
+                using (Stream s =_plateTiles.GetStream(wwtTilesDir, $"{file}.plate", level, tileX, tileY))
+                {
+                    if (s.Length == 0)
+                    {
+                        context.Response.Clear();
+                        context.Response.ContentType = "text/plain";
+                        context.Response.Write("No image");
+                        context.Response.End();
+                    }
+                    else
+                    {
+                        s.CopyTo(context.Response.OutputStream);
+                        context.Response.Flush();
+                        context.Response.End();
+                    }
                 }
-                byte[] data = new byte[length];
-                s.Read(data, 0, length);
-                context.Response.OutputStream.Write(data, 0, length);
-                context.Response.Flush();
-                context.Response.End();
-                return;
             }
         }
     }

--- a/src/WWT.Providers/Providers/tilethumbProvider.cs
+++ b/src/WWT.Providers/Providers/tilethumbProvider.cs
@@ -1,18 +1,22 @@
-using System.Configuration;
 using System.IO;
-using WWTWebservices;
 
 namespace WWT.Providers
 {
-    public class tilethumbProvider : RequestProvider
+    public class TilethumbProvider : RequestProvider
     {
+        private readonly FilePathOptions _options;
+
+        public TilethumbProvider(FilePathOptions options)
+        {
+            _options = options;
+        }
+
         public override void Run(IWwtContext context)
         {
             string name = context.Request.Params["name"];
-            string type = context.Request.Params["class"];
-            string path = ConfigurationManager.AppSettings["DSSTileCache"] + "\\imagesTiler\\thumbnails\\";
+            string path = Path.Combine(_options.DSSTileCache, "imagesTiler", "thumbnails");
+            string filename = Path.Combine(path, $"{name}.jpg");
 
-            string filename = path + name + ".jpg";
             if (File.Exists(filename))
             {
                 context.Response.WriteFile(filename);

--- a/src/WWTMVC5/WWTWeb/tiles.aspx
+++ b/src/WWTMVC5/WWTWeb/tiles.aspx
@@ -2,5 +2,5 @@
 
 <%@ Import Namespace="WWT.Providers" %>
 <%
-	RequestProvider.Get<tilesProvider>().Run(this);
+	RequestProvider.Get<TilesProvider>().Run(this);
 %>

--- a/src/WWTMVC5/WWTWeb/tiles2.aspx
+++ b/src/WWTMVC5/WWTWeb/tiles2.aspx
@@ -2,5 +2,5 @@
 
 <%@ Import Namespace="WWT.Providers" %>
 <%
-	RequestProvider.Get<tiles2Provider>().Run(this);
+	RequestProvider.Get<Tiles2Provider>().Run(this);
 %>

--- a/src/WWTMVC5/WWTWeb/tilethumb.aspx
+++ b/src/WWTMVC5/WWTWeb/tilethumb.aspx
@@ -2,5 +2,5 @@
 
 <%@ Import Namespace="WWT.Providers" %>
 <%
-	RequestProvider.Get<tilethumbProvider>().Run(this);
+    RequestProvider.Get<TilethumbProvider>().Run(this);
 %>

--- a/tests/WWT.Providers.Tests/HttpAutoSubstituteExtensions.cs
+++ b/tests/WWT.Providers.Tests/HttpAutoSubstituteExtensions.cs
@@ -95,5 +95,11 @@ namespace WWT.Providers.Tests
 
         public static AutoSubstituteBuilder ConfigureParameterQ(this AutoSubstituteBuilder builder, int level, int x, int y)
             => builder.RegisterAfterBuild<IParameters>((p, ctx) => p["Q"].Returns($"{level},{x},{y}"));
+
+        public static AutoSubstituteBuilder ConfigureParameterQ(this AutoSubstituteBuilder builder, object[] args)
+        {
+            var str = string.Join(",", args);
+            return builder.RegisterAfterBuild<IParameters>((p, ctx) => p["Q"].Returns(str));
+        }
     }
 }

--- a/tests/WWT.Providers.Tests/ProviderTests.cs
+++ b/tests/WWT.Providers.Tests/ProviderTests.cs
@@ -13,13 +13,13 @@ namespace WWT.Providers.Tests
     public abstract class ProviderTests<T>
         where T : RequestProvider
     {
-        private readonly Fixture _fixture;
-
         public ProviderTests()
         {
-            _fixture = new Fixture();
-            Options = _fixture.Create<FilePathOptions>();
+            Fixture = new Fixture();
+            Options = Fixture.Create<FilePathOptions>();
         }
+
+        protected Fixture Fixture { get; }
 
         protected FilePathOptions Options { get; }
 
@@ -45,20 +45,23 @@ namespace WWT.Providers.Tests
             Assert.Equal("text/plain", response.ContentType);
         }
 
+        protected virtual object[] GetParameterQ(int level, int x, int y)
+            => new object[] { level, x, y };
+
         [Fact]
         public void ExpectedTests()
         {
             for (int level = 0; level < MaxLevel; level++)
             {
                 // Arrange
-                var data = _fixture.CreateMany<byte>().ToArray();
-                var x = _fixture.Create<int>();
-                var y = _fixture.Create<int>();
+                var data = Fixture.CreateMany<byte>().ToArray();
+                var x = Fixture.Create<int>();
+                var y = Fixture.Create<int>();
 
                 using var container = AutoSubstitute.Configure()
                     .InitializeProviderTests()
                     .Provide(Options)
-                    .ConfigureParameterQ(level, x, y)
+                    .ConfigureParameterQ(GetParameterQ(level, x, y))
                     .Build();
 
                 GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>(), level, x, y).Returns(new MemoryStream(data));
@@ -80,14 +83,14 @@ namespace WWT.Providers.Tests
             foreach (var level in Enumerable.Range(0, maxLevel))
             {
                 // Arrange
-                var data = _fixture.CreateMany<byte>().ToArray();
-                var x = _fixture.Create<int>();
-                var y = _fixture.Create<int>();
+                var data = Fixture.CreateMany<byte>().ToArray();
+                var x = Fixture.Create<int>();
+                var y = Fixture.Create<int>();
 
                 using var container = AutoSubstitute.Configure()
                     .InitializeProviderTests()
                     .Provide(Options)
-                    .ConfigureParameterQ(level, x, y)
+                    .ConfigureParameterQ(GetParameterQ(level, x, y))
                     .Build();
 
                 GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>(), level, x, y).Returns(_ => throw new InvalidOperationException());
@@ -113,14 +116,14 @@ namespace WWT.Providers.Tests
         public void EmptyResult()
         {
             // Arrange
-            var level = _fixture.Create<int>() % MaxLevel;
-            var x = _fixture.Create<int>();
-            var y = _fixture.Create<int>();
+            var level = Fixture.Create<int>() % MaxLevel;
+            var x = Fixture.Create<int>();
+            var y = Fixture.Create<int>();
 
             using var container = AutoSubstitute.Configure()
                 .Provide(Options)
                 .InitializeProviderTests()
-                .ConfigureParameterQ(level, x, y)
+                .ConfigureParameterQ(GetParameterQ(level, x, y))
                 .Build();
 
             var empty = new MemoryStream();
@@ -138,14 +141,14 @@ namespace WWT.Providers.Tests
         public void NullResult()
         {
             // Arrange
-            var level = _fixture.Create<int>() % MaxLevel;
-            var x = _fixture.Create<int>();
-            var y = _fixture.Create<int>();
+            var level = Fixture.Create<int>() % MaxLevel;
+            var x = Fixture.Create<int>();
+            var y = Fixture.Create<int>();
 
             using var container = AutoSubstitute.Configure()
                 .Provide(Options)
                 .InitializeProviderTests()
-                .ConfigureParameterQ(level, x, y)
+                .ConfigureParameterQ(GetParameterQ(level, x, y))
                 .Build();
 
             GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>(), level, x, y).Returns((Stream)null);
@@ -176,13 +179,13 @@ namespace WWT.Providers.Tests
             foreach (var level in GetLevelsAboveMax())
             {
                 // Arrange
-                var x = _fixture.Create<int>();
-                var y = _fixture.Create<int>();
+                var x = Fixture.Create<int>();
+                var y = Fixture.Create<int>();
 
                 using var container = AutoSubstitute.Configure()
                     .Provide(Options)
                     .InitializeProviderTests()
-                    .ConfigureParameterQ(level, x, y)
+                    .ConfigureParameterQ(GetParameterQ(level, x, y))
                     .Build();
 
                 // Act
@@ -196,7 +199,7 @@ namespace WWT.Providers.Tests
             {
                 for (int i = 0; i < 10; i++)
                 {
-                    yield return MaxLevel + _fixture.Create<int>();
+                    yield return MaxLevel + Fixture.Create<int>();
                 }
             }
         }

--- a/tests/WWT.Providers.Tests/Tiles2ProviderTests.cs
+++ b/tests/WWT.Providers.Tests/Tiles2ProviderTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using AutoFixture;
+using System.IO;
+using WWTWebservices;
+using Xunit;
+
+namespace WWT.Providers.Tests
+{
+    public class Tiles2ProviderTests : ProviderTests<Tiles2Provider>
+    {
+        private readonly string _fileName;
+
+        public Tiles2ProviderTests()
+        {
+            _fileName = Fixture.Create<string>();
+        }
+
+        protected override object[] GetParameterQ(int level, int x, int y)
+            => new object[] { level, x, y, _fileName };
+
+        protected override int MaxLevel => 9;
+
+        protected override Stream GetStreamFromPlateTilePyramid(IPlateTilePyramid plateTiles, int level, int x, int y)
+            => plateTiles.GetStream(Options.WwtTilesDir, $"{_fileName}.plate", -1, level, x, y);
+
+        protected override Action<IResponse> NullStreamResponseHandler => null;
+
+        protected override Action<IResponse> StreamExceptionResponseHandler => null;
+
+        protected override void ExpectedResponseAboveMaxLevel(IResponse response)
+        {
+            Assert.Empty(response.ContentType);
+            Assert.Empty(response.OutputStream.ToArray());
+        }
+    }
+}

--- a/tests/WWT.Providers.Tests/TilesProviderTests.cs
+++ b/tests/WWT.Providers.Tests/TilesProviderTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using AutoFixture;
+using System.IO;
+using WWTWebservices;
+using Xunit;
+
+namespace WWT.Providers.Tests
+{
+    public class TilesProviderTests : ProviderTests<TilesProvider>
+    {
+        private readonly string _fileName;
+
+        public TilesProviderTests()
+        {
+            _fileName = Fixture.Create<string>();
+        }
+
+        protected override object[] GetParameterQ(int level, int x, int y)
+            => new object[] { level, x, y, _fileName };
+
+        protected override int MaxLevel => 7;
+
+        protected override Stream GetStreamFromPlateTilePyramid(IPlateTilePyramid plateTiles, int level, int x, int y)
+            => plateTiles.GetStream(Options.WwtTilesDir, $"{_fileName}.plate", level, x, y);
+
+        protected override Action<IResponse> NullStreamResponseHandler => null;
+
+        protected override Action<IResponse> StreamExceptionResponseHandler => null;
+
+        protected override void ExpectedResponseAboveMaxLevel(IResponse response)
+        {
+            Assert.Empty(response.ContentType);
+            Assert.Empty(response.OutputStream.ToArray());
+        }
+    }
+}

--- a/tests/WWT.Providers.Tests/TwoMASSOctProviderTests.cs
+++ b/tests/WWT.Providers.Tests/TwoMASSOctProviderTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO;
+using WWTWebservices;
+using Xunit;
+
+namespace WWT.Providers.Tests
+{
+    public class TwoMASSOctProviderTests : ProviderTests<TwoMASSOctProvider>
+    {
+        protected override int MaxLevel => 7;
+
+        protected override Action<IResponse> NullStreamResponseHandler => null;
+
+        protected override Action<IResponse> StreamExceptionResponseHandler => null;
+
+        protected override void ExpectedResponseAboveMaxLevel(IResponse response)
+        {
+            Assert.Empty(response.ContentType);
+            Assert.Empty(response.OutputStream.ToArray());
+        }
+
+        protected override Stream GetStreamFromPlateTilePyramid(IPlateTilePyramid plateTiles, int level, int x, int y)
+            => plateTiles.GetStream(Options.WwtTilesDir, $"2massoctset.plate", level, x, y);
+    }
+}

--- a/tests/WWT.Providers.Tests/TwoMassToastProviderTests.cs
+++ b/tests/WWT.Providers.Tests/TwoMassToastProviderTests.cs
@@ -1,0 +1,13 @@
+﻿using System.IO;
+using WWTWebservices;
+
+namespace WWT.Providers.Tests
+{
+    public class TwoMassToastProviderTests : ProviderTests<TwoMassToastProvider>
+    {
+        protected override int MaxLevel => 7;
+
+        protected override Stream GetStreamFromPlateTilePyramid(IPlateTilePyramid plateTiles, int level, int x, int y)
+            => plateTiles.GetStream(Options.WwtTilesDir, "2MassToast0to7.plate", level, x, y);
+    }
+}

--- a/tests/WWT.Providers.Tests/TychoOctProviderTests.cs
+++ b/tests/WWT.Providers.Tests/TychoOctProviderTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO;
+using WWTWebservices;
+using Xunit;
+
+namespace WWT.Providers.Tests
+{
+    public class TychoOctProviderTests : ProviderTests<TychoOctProvider>
+    {
+        protected override int MaxLevel => 7;
+
+        protected override Action<IResponse> NullStreamResponseHandler => null;
+
+        protected override Action<IResponse> StreamExceptionResponseHandler => null;
+
+        protected override void ExpectedResponseAboveMaxLevel(IResponse response)
+        {
+            Assert.Empty(response.ContentType);
+            Assert.Empty(response.OutputStream.ToArray());
+        }
+
+        protected override Stream GetStreamFromPlateTilePyramid(IPlateTilePyramid plateTiles, int level, int x, int y)
+            => plateTiles.GetStream(Options.WwtTilesDir, $"tychotoast.plate", level, x, y);
+    }
+}


### PR DESCRIPTION
This was fairly straightforward, but TwoMassToasProvider had a branch
that was not accessible. In CoreDataMap.docx, there is a comment that
this plate file is almost surely a mistake. Since there was no way to
reach it with the parameters, this change removes it.