### PR TITLE
Use IPlateTilePyramid in providers starting with v and w

### DIFF
--- a/src/WWT.Providers/Providers/versionProvider.cs
+++ b/src/WWT.Providers/Providers/versionProvider.cs
@@ -1,14 +1,13 @@
-using System.Configuration;
+using System.IO;
 
 namespace WWT.Providers
 {
-    public class versionProvider : RequestProvider
+    public class VersionProvider : RequestProvider
     {
         public override void Run(IWwtContext context)
         {
             context.Response.AddHeader("Cache-Control", "no-cache");
-            string webDir = ConfigurationManager.AppSettings["WWTWEBDIR"];
-            context.Response.WriteFile(webDir + @"\wwt2\version.txt");
+            context.Response.WriteFile(context.MapPath(Path.Combine("..", "wwt2", "version.txt")));
         }
     }
 }

--- a/src/WWT.Providers/Providers/versionsProvider.cs
+++ b/src/WWT.Providers/Providers/versionsProvider.cs
@@ -1,20 +1,21 @@
-using System.Configuration;
+using System.IO;
 
 namespace WWT.Providers
 {
-    public class versionsProvider : RequestProvider
+    public class VersionsProvider : RequestProvider
     {
         public override void Run(IWwtContext context)
         {
-            string wwt2dir = ConfigurationManager.AppSettings["WWT2DIR"];
             context.Response.AddHeader("Cache-Control", "no-cache");
 
+            var wwt2dir = context.MapPath(Path.Combine("..", "wwt2"));
+
             context.Response.Write("ClientVersion:");
-            context.Response.WriteFile(wwt2dir + @"\version.txt");
+            context.Response.WriteFile(Path.Combine(wwt2dir, "version.txt"));
             context.Response.Write("\n");
-            context.Response.WriteFile(wwt2dir + @"\dataversion.txt");
+            context.Response.WriteFile(Path.Combine(wwt2dir, "dataversion.txt"));
             context.Response.Write("\nMessage:");
-            context.Response.WriteFile(wwt2dir + @"\message.txt");
+            context.Response.WriteFile(Path.Combine(wwt2dir, "message.txt"));
         }
     }
 }

--- a/src/WWT.Providers/Providers/vlssToastProvider.cs
+++ b/src/WWT.Providers/Providers/vlssToastProvider.cs
@@ -1,12 +1,20 @@
 using System;
-using System.Configuration;
 using System.IO;
 using WWTWebservices;
 
 namespace WWT.Providers
 {
-    public class vlssToastProvider : RequestProvider
+    public class VlssToastProvider : RequestProvider
     {
+        private readonly IPlateTilePyramid _plateTiles;
+        private readonly FilePathOptions _options;
+
+        public VlssToastProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        {
+            _plateTiles = plateTiles;
+            _options = options;
+        }
+
         public override void Run(IWwtContext context)
         {
             string query = context.Request.Params["Q"];
@@ -14,21 +22,17 @@ namespace WWT.Providers
             int level = Convert.ToInt32(values[0]);
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
-            string file = "VLSS";
-            string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
-
 
             if (level < 8)
             {
                 context.Response.ContentType = "image/png";
-                Stream s = PlateTilePyramid.GetFileStream(String.Format(wwtTilesDir + "\\{0}.plate", file), level, tileX, tileY);
-                int length = (int)s.Length;
-                byte[] data = new byte[length];
-                s.Read(data, 0, length);
-                context.Response.OutputStream.Write(data, 0, length);
-                context.Response.Flush();
-                context.Response.End();
-                return;
+
+                using (Stream s = _plateTiles.GetStream(_options.WwtTilesDir, "VLSS.plate", level, tileX, tileY))
+                {
+                    s.CopyTo(context.Response.OutputStream);
+                    context.Response.Flush();
+                    context.Response.End();
+                }
             }
         }
     }

--- a/src/WWT.Providers/Providers/wmapProvider.cs
+++ b/src/WWT.Providers/Providers/wmapProvider.cs
@@ -1,12 +1,20 @@
 using System;
-using System.Configuration;
 using System.IO;
 using WWTWebservices;
 
 namespace WWT.Providers
 {
-    public class wmapProvider : RequestProvider
+    public class WmapProvider : RequestProvider
     {
+        private readonly IPlateTilePyramid _plateTiles;
+        private readonly FilePathOptions _options;
+
+        public WmapProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        {
+            _plateTiles = plateTiles;
+            _options = options;
+        }
+
         public override void Run(IWwtContext context)
         {
             string query = context.Request.Params["Q"];
@@ -14,21 +22,18 @@ namespace WWT.Providers
             int level = Convert.ToInt32(values[0]);
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
-            string file = "WMAP";
-            string wwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
-
 
             if (level < 8)
             {
                 context.Response.ContentType = "image/png";
-                Stream s = PlateTilePyramid.GetFileStream(String.Format(wwtTilesDir + "\\{0}.plate", file), level, tileX, tileY);
-                int length = (int)s.Length;
-                byte[] data = new byte[length];
-                s.Read(data, 0, length);
-                context.Response.OutputStream.Write(data, 0, length);
-                context.Response.Flush();
-                context.Response.End();
-                return;
+
+                using (Stream s = _plateTiles.GetStream(_options.WwtTilesDir, "WMAP.plate", level, tileX, tileY))
+                {
+                    s.CopyTo(context.Response.OutputStream);
+                    context.Response.Flush();
+                    context.Response.End();
+                    return;
+                }
             }
         }
     }

--- a/src/WWTMVC5/WWTWeb/version.aspx
+++ b/src/WWTMVC5/WWTWeb/version.aspx
@@ -2,5 +2,5 @@
 
 <%@ Import Namespace="WWT.Providers" %>
 <%
-	RequestProvider.Get<versionProvider>().Run(this);
+	RequestProvider.Get<VersionProvider>().Run(this);
 %>

--- a/src/WWTMVC5/WWTWeb/versions.aspx
+++ b/src/WWTMVC5/WWTWeb/versions.aspx
@@ -2,5 +2,5 @@
 
 <%@ Import Namespace="WWT.Providers" %>
 <%
-	RequestProvider.Get<versionsProvider>().Run(this);
+	RequestProvider.Get<VersionsProvider>().Run(this);
 %>

--- a/src/WWTMVC5/WWTWeb/vlssToast.aspx
+++ b/src/WWTMVC5/WWTWeb/vlssToast.aspx
@@ -2,5 +2,5 @@
 
 <%@ Import Namespace="WWT.Providers" %>
 <%
-	RequestProvider.Get<vlssToastProvider>().Run(this);
+	RequestProvider.Get<VlssToastProvider>().Run(this);
 %>

--- a/src/WWTMVC5/WWTWeb/wmap.aspx
+++ b/src/WWTMVC5/WWTWeb/wmap.aspx
@@ -2,5 +2,5 @@
 
 <%@ Import Namespace="WWT.Providers" %>
 <%
-	RequestProvider.Get<wmapProvider>().Run(this);
+	RequestProvider.Get<WmapProvider>().Run(this);
 %>

--- a/tests/WWT.Providers.Tests/VlssToastProviderTests.cs
+++ b/tests/WWT.Providers.Tests/VlssToastProviderTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO;
+using WWTWebservices;
+using Xunit;
+
+namespace WWT.Providers.Tests
+{
+    public class VlssToastProviderTests : ProviderTests<VlssToastProvider>
+    {
+        protected override int MaxLevel => 7;
+
+        protected override Action<IResponse> NullStreamResponseHandler => null;
+
+        protected override Action<IResponse> StreamExceptionResponseHandler => null;
+
+        protected override void ExpectedResponseAboveMaxLevel(IResponse response)
+        {
+            Assert.Empty(response.ContentType);
+            Assert.Empty(response.OutputStream.ToArray());
+        }
+
+        protected override Stream GetStreamFromPlateTilePyramid(IPlateTilePyramid plateTiles, int level, int x, int y)
+            => plateTiles.GetStream(Options.WwtTilesDir, "VLSS.plate", level, x, y);
+    }
+}

--- a/tests/WWT.Providers.Tests/WmapProviderTests.cs
+++ b/tests/WWT.Providers.Tests/WmapProviderTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO;
+using WWTWebservices;
+using Xunit;
+
+namespace WWT.Providers.Tests
+{
+    public class WmapProviderTests : ProviderTests<WmapProvider>
+    {
+        protected override int MaxLevel => 7;
+
+        protected override Action<IResponse> NullStreamResponseHandler => null;
+
+        protected override Action<IResponse> StreamExceptionResponseHandler => null;
+
+        protected override void ExpectedResponseAboveMaxLevel(IResponse response)
+        {
+            Assert.Empty(response.ContentType);
+            Assert.Empty(response.OutputStream.ToArray());
+        }
+
+        protected override Stream GetStreamFromPlateTilePyramid(IPlateTilePyramid plateTiles, int level, int x, int y)
+            => plateTiles.GetStream(Options.WwtTilesDir, "WMAP.plate", level, x, y);
+    }
+}


### PR DESCRIPTION
This also cleans up some of the file access in the version endpoints to use MapPath.