### PR TITLE
Access platefile2 by seeking into blob

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="azuresdk" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/WWT.Azure/WWT.Azure.csproj
+++ b/src/WWT.Azure/WWT.Azure.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.7.0-alpha.20201016.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WWT.PlateFiles/PlateFile2.cs
+++ b/src/WWT.PlateFiles/PlateFile2.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using WWT.Azure;
 
 namespace WWTWebservices
 {
@@ -225,28 +226,14 @@ namespace WWTWebservices
 
         }
 
-        public static Stream GetFileStream(Stream stream, int tag, int level, int x, int y)
+        public static Stream GetImageStream(Stream stream, int tag, int level, int x, int y)
         {
             PlateFile2 plate = new PlateFile2(stream);
 
             Stream result = plate.GetFileStream(tag, level, x, y);
 
-            plate.Close();
-
             return result;
         }
-
-        public static Stream GetFileStream(string filename, int tag, int level, int x, int y)
-        {
-            PlateFile2 plate = new PlateFile2(filename, true);
-
-            Stream stream = plate.GetFileStream(tag, level, x, y);
-
-            plate.Close();
-
-            return stream;
-        }
-
 
         public IEnumerable<DirectoryEntry> GetEntries()
         {
@@ -372,27 +359,20 @@ namespace WWTWebservices
 
             DirectoryEntry de;
 
-
             while (hep != 0)
             {
                 de = GetDirectoryEntry(hep);
 
                 if ((de.x == x) && (de.y == y) && ((de.tag == tag) || (tag == -1)) && (de.level == level))
                 {
-                    MemoryStream ms = null;
-
-                    byte[] buffer = new byte[de.size];
-                    dataStream.Seek(de.location, SeekOrigin.Begin);
-                    dataStream.Read(buffer, 0, (int)de.size);
-                    ms = new MemoryStream(buffer);
-                    return ms;
+                    return new StreamSlice(dataStream, de.location, de.size);
                 }
                 else
                 {
                     hep = de.NextEntryInChain;
                 }
-
             }
+
             return null;
         }
 

--- a/src/WWT.PlateFiles/StreamSlice.cs
+++ b/src/WWT.PlateFiles/StreamSlice.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WWT.Azure
+{
+    /// <summary>
+    /// An implementation of <see cref="Stream"/> that allows for slicing of another stream given
+    /// an initial offset and length.
+    /// </summary>
+    internal class StreamSlice : Stream
+    {
+        private Stream _baseStream;
+        private long _position;
+
+        private readonly long _length;
+
+        public StreamSlice(Stream baseStream, long offset, long length)
+        {
+            _baseStream = baseStream ?? throw new ArgumentNullException(nameof(baseStream));
+            _length = length;
+
+            if (!baseStream.CanRead)
+            {
+                throw new ArgumentException("Stream must support read.");
+            }
+
+            if (!baseStream.CanSeek)
+            {
+                throw new ArgumentException("Stream must support seek.");
+            }
+
+            if (offset < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
+
+            baseStream.Seek(offset, SeekOrigin.Current);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => ReadInternalAsync(buffer, offset, count, true, cancellationToken).AsTask();
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => ReadInternalAsync(buffer, offset, count, isAsync: false, default).Result;
+
+        /// <summary>
+        /// A read implementation that can be either async or synchronous to reduce duplication of code. The synchronous pathway will always be completed.
+        /// </summary>
+        private async ValueTask<int> ReadInternalAsync(byte[] buffer, int offset, int count, bool isAsync, CancellationToken cancellationToken)
+        {
+            CheckDisposed();
+            var remaining = _length - _position;
+
+            if (remaining <= 0)
+            {
+                return 0;
+            }
+
+            if (remaining < count)
+            {
+                count = (int)remaining;
+            }
+
+            var read = isAsync
+                ? await _baseStream.ReadAsync(buffer, offset, count, cancellationToken)
+                : _baseStream.Read(buffer, offset, count);
+
+            _position += read;
+
+            return read;
+        }
+
+        private void CheckDisposed()
+        {
+            if (_baseStream == null)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+        }
+
+        public override long Length
+        {
+            get
+            {
+                CheckDisposed();
+                return _length;
+            }
+        }
+
+        public override bool CanRead
+        {
+            get
+            {
+                CheckDisposed();
+                return true;
+            }
+        }
+
+        public override bool CanWrite
+        {
+            get
+            {
+                CheckDisposed();
+                return false;
+            }
+        }
+
+        public override bool CanSeek
+        {
+            get
+            {
+                CheckDisposed();
+                return false;
+            }
+        }
+
+        public override long Position
+        {
+            get
+            {
+                CheckDisposed();
+                return _position;
+            }
+            set => throw new NotSupportedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Flush()
+        {
+            CheckDisposed();
+            _baseStream.Flush();
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            CheckDisposed();
+            return base.FlushAsync(cancellationToken);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+            {
+                if (_baseStream != null)
+                {
+                    try { _baseStream.Dispose(); }
+                    catch { }
+                    _baseStream = null;
+                }
+            }
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => throw new NotImplementedException();
+    }
+}

--- a/src/WWT.Providers/Providers/MarsHiriseProvider.cs
+++ b/src/WWT.Providers/Providers/MarsHiriseProvider.cs
@@ -106,7 +106,7 @@ namespace WWT.Providers
 
             Stream stream = blob.OpenRead();
 
-            return PlateFile2.GetFileStream(stream, id, level, tileX, tileY);
+            return PlateFile2.GetImageStream(stream, id, level, tileX, tileY);
         }
 
         private UInt32 ComputeHash(int level, int x, int y)

--- a/src/WWT.Providers/Providers/MarsMocProvider.cs
+++ b/src/WWT.Providers/Providers/MarsMocProvider.cs
@@ -101,7 +101,7 @@ namespace WWT.Providers
 
             Stream stream = blob.OpenRead();
 
-            return PlateFile2.GetFileStream(stream, -1, level, tileX, tileY);
+            return PlateFile2.GetImageStream(stream, -1, level, tileX, tileY);
         }
 
         private UInt32 ComputeHash(int level, int x, int y)

--- a/src/WWTMVC5/Web.config
+++ b/src/WWTMVC5/Web.config
@@ -241,7 +241,7 @@ Content-Type: application/x-wt-->
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159E12E44C8" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.5.1.0" newVersion="1.5.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral"/>

--- a/wwt-website.sln
+++ b/wwt-website.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		init.ps1 = init.ps1
 		INSTALL.md = INSTALL.md
 		LICENSE = LICENSE
+		nuget.config = nuget.config
 		README.md = README.md
 	EndProjectSection
 EndProject


### PR DESCRIPTION
This change uses a pre-release of Azure SDK that enables seeking. This allows plate files to be uploaded directly to blob storage and then only the section needed will be copied.