### PR TITLE
Use Ms.DependencyInjection instead of Unity for requests

### DIFF
--- a/src/WWT.Azure/AzurePlateTilePyramidOptions.cs
+++ b/src/WWT.Azure/AzurePlateTilePyramidOptions.cs
@@ -11,5 +11,13 @@ namespace WWT.Azure
         public bool SkipIfExists { get; set; }
 
         public bool OverwriteExisting { get; set; }
+
+        /// <summary>
+        /// TODO: The current storage account is a classic storage account and managed identity is not supported
+        /// If the setting is a URL, we'll use managed identity. Otherwise, we'll expect it to be a connection string.
+        /// </summary>
+        public string StorageAccount { get; set; }
+
+        public bool UseAzurePlateFiles { get; set; }
     }
 }

--- a/src/WWT.Azure/AzureWwtExtensions.cs
+++ b/src/WWT.Azure/AzureWwtExtensions.cs
@@ -1,0 +1,40 @@
+﻿using Azure.Core;
+using Azure.Identity;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using WWTWebservices;
+
+namespace WWT.Azure
+{
+    public static class AzureWwtExtensions
+    {
+        public static void AddAzureServices(this IServiceCollection services, Action<AzurePlateTilePyramidOptions> configure)
+        {
+            var azureOptions = new AzurePlateTilePyramidOptions();
+
+            configure(azureOptions);
+
+            services.AddSingleton(azureOptions);
+
+            if (azureOptions.UseAzurePlateFiles)
+            {
+                if (Uri.TryCreate(azureOptions.StorageAccount, UriKind.Absolute, out var storageUri))
+                {
+                    services.AddSingleton<TokenCredential, DefaultAzureCredential>();
+                    services.AddTransient(ctx => new BlobServiceClient(storageUri, ctx.GetRequiredService<TokenCredential>()));
+                }
+                else
+                {
+                    services.AddTransient(_ => new BlobServiceClient(azureOptions.StorageAccount));
+                }
+
+                services.AddSingleton<IPlateTilePyramid, AzurePlateTilePyramid>();
+            }
+            else
+            {
+                services.AddSingleton<IPlateTilePyramid, FilePlateTilePyramid>();
+            }
+        }
+    }
+}

--- a/src/WWT.Azure/WWT.Azure.csproj
+++ b/src/WWT.Azure/WWT.Azure.csproj
@@ -6,7 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.7.0-alpha.20201016.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WWT.PlateFiles/FilePlateTilePyramid.cs
+++ b/src/WWT.PlateFiles/FilePlateTilePyramid.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace WWTWebservices
 {
-    public class ConfigurationManagerFilePlateTilePyramid : IPlateTilePyramid
+    public class FilePlateTilePyramid : IPlateTilePyramid
     {
         public async IAsyncEnumerable<string> GetPlateNames([EnumeratorCancellation]CancellationToken token)
         {

--- a/src/WWT.PlateFiles/WWT.PlateFiles.csproj
+++ b/src/WWT.PlateFiles/WWT.PlateFiles.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WWT.Providers/FilePathOptions.cs
+++ b/src/WWT.Providers/FilePathOptions.cs
@@ -1,20 +1,7 @@
-﻿using System.Configuration;
-using WWTWebservices;
-
-namespace WWT.Providers
+﻿namespace WWT.Providers
 {
     public class FilePathOptions
     {
-        public static FilePathOptions CreateFromConfig()
-            => new FilePathOptions
-            {
-                DssTerapixelDir = ConfigurationManager.AppSettings["DssTerapixelDir"],
-                DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"],
-                DssToastPng = ConfigurationManager.AppSettings["DSSTOASTPNG"],
-                WWTDEMDir = ConfigurationManager.AppSettings["WWTDEMDir"],
-                WwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"],
-                WwtGalexDir = ConfigurationManager.AppSettings["WWTGALEXDIR"],
-            };
 
         public string DssTerapixelDir { get; set; }
 

--- a/src/WWT.Providers/RequestProvidersExtensions.cs
+++ b/src/WWT.Providers/RequestProvidersExtensions.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+
+namespace WWT.Providers
+{
+    public static class RequestProvidersExtensions
+    {
+        public static void AddRequestProviders(this IServiceCollection services, Action<FilePathOptions> config)
+        {
+            var types = typeof(RequestProvider).Assembly.GetTypes()
+                .Where(t => !t.IsAbstract && typeof(RequestProvider).IsAssignableFrom(t));
+
+            foreach (var type in types)
+            {
+                services.AddSingleton(type);
+            }
+
+            var options = new FilePathOptions();
+
+            config(options);
+
+            services.AddSingleton(options);
+        }
+    }
+}

--- a/src/WWT.Providers/WWT.Providers.csproj
+++ b/src/WWT.Providers/WWT.Providers.csproj
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.9" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
   </ItemGroup>

--- a/src/WWTMVC5/WWTMVC5.csproj
+++ b/src/WWTMVC5/WWTMVC5.csproj
@@ -1441,6 +1441,9 @@
     <PackageReference Include="Microsoft.Data.Services.Client">
       <Version>5.8.3</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection">
+      <Version>3.1.9</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel">
       <Version>6.1.7600.16394</Version>
     </PackageReference>

--- a/src/WWTMVC5/Web.config
+++ b/src/WWTMVC5/Web.config
@@ -207,6 +207,10 @@ Content-Type: application/x-wt-->
   </entityFramework>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
+			</dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>


### PR DESCRIPTION
We're currently using unity for dependency injection and aren't using any features that are specific there. MS.DI is a simpler abstraction and has some simpler ways of doing things like decorators so that we can easily do things such as adding a caching layer on top. This will also make it easier to move to ASP.NET Core when we're ready to do that.

The containers for the community site had already been its own set of registrations, so this reverts back to that pattern so the communities site continues to use Unity.