### PR TITLE
Add caching to IPlateTilePyramid

### DIFF
--- a/src/WWT.PlateFiles.Caching/CachedPlateTilePyramid.cs
+++ b/src/WWT.PlateFiles.Caching/CachedPlateTilePyramid.cs
@@ -1,0 +1,114 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using WWTWebservices;
+
+namespace WWT.PlateFiles.Caching
+{
+    public abstract class CachedPlateTilePyramid : IPlateTilePyramid
+    {
+        public CachedPlateTilePyramid(IPlateTilePyramid other)
+        {
+            InnerPyramid = other;
+        }
+
+        public IPlateTilePyramid InnerPyramid { get; }
+
+        public IAsyncEnumerable<string> GetPlateNames(CancellationToken token)
+            => InnerPyramid.GetPlateNames(token);
+
+        public Stream GetStream(string pathPrefix, string plateName, int level, int x, int y)
+        {
+            var context = new TileContext(InnerPyramid)
+            {
+                PathPrefix = pathPrefix,
+                PlateName = plateName,
+                Level = level,
+                X = x,
+                Y = y
+            };
+
+            return new MemoryStream(GetOrUpdateCache(context));
+        }
+
+        public Stream GetStream(string pathPrefix, string plateName, int tag, int level, int x, int y)
+        {
+            var context = new TileContext(InnerPyramid)
+            {
+                PathPrefix = pathPrefix,
+                PlateName = plateName,
+                Tag = tag,
+                Level = level,
+                X = x,
+                Y = y
+            };
+
+            return new MemoryStream(GetOrUpdateCache(context));
+        }
+
+        protected abstract byte[] GetOrUpdateCache(TileContext context);
+
+        public class TileContext
+        {
+            private readonly IPlateTilePyramid _other;
+
+            public TileContext(IPlateTilePyramid other)
+            {
+                _other = other;
+            }
+
+            public string GetKey()
+            {
+                var sb = new StringBuilder(PathPrefix.Length + PlateName.Length + 20);
+
+                sb.Append(PathPrefix);
+                sb.Append("_");
+                sb.Append(PlateName);
+                sb.Append("_");
+
+                if (Tag.HasValue)
+                {
+                    sb.Append(Tag.Value);
+                    sb.Append("_");
+                }
+
+                sb.Append("L");
+                sb.Append(Level.ToString());
+
+                sb.Append("X");
+                sb.Append(X.ToString());
+
+                sb.Append("Y");
+                sb.Append(Y.ToString());
+
+                return sb.ToString();
+            }
+
+            public string PathPrefix { get; set; }
+
+            public string PlateName { get; set; }
+
+            public int? Tag { get; set; }
+
+            public int Level { get; set; }
+
+            public int X { get; set; }
+
+            public int Y { get; set; }
+
+            public byte[] GetResult()
+            {
+                var result = Tag.HasValue
+                    ? _other.GetStream(PathPrefix, PlateName, Tag.Value, Level, X, Y)
+                    : _other.GetStream(PathPrefix, PlateName, Level, X, Y);
+
+                using (var ms = new MemoryStream())
+                {
+                    result.CopyTo(ms);
+                    return ms.ToArray();
+                }
+            }
+        }
+    }
+}

--- a/src/WWT.PlateFiles.Caching/CachingOptions.cs
+++ b/src/WWT.PlateFiles.Caching/CachingOptions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace WWT.PlateFiles.Caching
+{
+    public class CachingOptions
+    {
+        public bool UseCaching { get; set; }
+
+        public TimeSpan SlidingExpiration { get; set; } = TimeSpan.FromMinutes(5);
+
+        public string RedisCacheConnectionString { get; set; }
+    }
+}

--- a/src/WWT.PlateFiles.Caching/InMemoryCachedPlateTilePyramid.cs
+++ b/src/WWT.PlateFiles.Caching/InMemoryCachedPlateTilePyramid.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+using WWTWebservices;
+
+namespace WWT.PlateFiles.Caching
+{
+    public class InMemoryCachedPlateTilePyramid : CachedPlateTilePyramid
+    {
+        private readonly MemoryCache _cache;
+        private readonly MemoryCacheEntryOptions _options;
+
+        public InMemoryCachedPlateTilePyramid(IPlateTilePyramid other, CachingOptions options)
+            : base(other)
+        {
+            _cache = new MemoryCache(new MemoryCacheOptions());
+            _options = new MemoryCacheEntryOptions
+            {
+                SlidingExpiration = options.SlidingExpiration
+            };
+        }
+
+        protected override byte[] GetOrUpdateCache(TileContext context)
+        {
+            var key = context.GetKey();
+
+            if (_cache.TryGetValue(key, out var cached) && cached is byte[] cachedBytes)
+            {
+                return cachedBytes;
+            }
+
+            var result = context.GetResult();
+
+            _cache.Set(key, result, _options);
+
+            return result;
+        }
+    }
+}

--- a/src/WWT.PlateFiles.Caching/RedisCachedPlateTilePyramid.cs
+++ b/src/WWT.PlateFiles.Caching/RedisCachedPlateTilePyramid.cs
@@ -1,0 +1,45 @@
+﻿using StackExchange.Redis;
+using System;
+using WWTWebservices;
+
+namespace WWT.PlateFiles.Caching
+{
+    public class RedisCachedPlateTilePyramid : CachedPlateTilePyramid
+    {
+        private readonly IConnectionMultiplexer _connection;
+        private readonly TimeSpan _expiry;
+
+        public RedisCachedPlateTilePyramid(
+            IPlateTilePyramid other,
+            IConnectionMultiplexer connection,
+            CachingOptions options)
+            : base(other)
+        {
+            _connection = connection;
+            _expiry = options.SlidingExpiration;
+        }
+
+        protected override byte[] GetOrUpdateCache(TileContext context)
+        {
+            var key = context.GetKey();
+
+            var db = _connection.GetDatabase();
+            var cached = db.StringGet(key);
+
+            if (cached.HasValue)
+            {
+                return cached;
+            }
+            else
+            {
+                var result = context.GetResult();
+
+                // No need to block for the transfer to actually complete. The caching is done asynchronously and
+                // will be available at some point in the near future.
+                db.StringSet(key, result, _expiry, When.Always, CommandFlags.FireAndForget);
+
+                return result;
+            }
+        }
+    }
+}

--- a/src/WWT.PlateFiles.Caching/WWT.PlateFiles.Caching.csproj
+++ b/src/WWT.PlateFiles.Caching/WWT.PlateFiles.Caching.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WWT.PlateFiles\WWT.PlateFiles.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.9" />
+    <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.9" />
+    <PackageReference Include="Scrutor" Version="3.2.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/WWT.PlateFiles.Caching/WwtCachingExtensions.cs
+++ b/src/WWT.PlateFiles.Caching/WwtCachingExtensions.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
+using System;
+using WWT.PlateFiles.Caching;
+using WWTWebservices;
+
+namespace WWT
+{
+    public static class WwtCachingExtensions
+    {
+        public static void AddCaching(this IServiceCollection services, Action<CachingOptions> configure)
+        {
+            var options = new CachingOptions();
+
+            configure(options);
+
+            services.AddSingleton(options);
+
+            if (options.UseCaching)
+            {
+                if (!string.IsNullOrEmpty(options.RedisCacheConnectionString))
+                {
+                    services.AddSingleton<IConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect(options.RedisCacheConnectionString));
+                    services.Decorate<IPlateTilePyramid, RedisCachedPlateTilePyramid>();
+                }
+                else
+                {
+                    services.Decorate<IPlateTilePyramid, InMemoryCachedPlateTilePyramid>();
+                }
+            }
+        }
+    }
+}

--- a/src/WWTMVC5/Global.asax.cs
+++ b/src/WWTMVC5/Global.asax.cs
@@ -12,6 +12,7 @@ using Unity;
 using Unity.AspNet.Mvc;
 using WWT.Azure;
 using WWT.Providers;
+using WWT;
 using WWTWebservices;
 
 namespace WWTMVC5
@@ -83,6 +84,13 @@ namespace WWTMVC5
             {
                 options.StorageAccount = ConfigurationManager.AppSettings["AzurePlateFileStorageAccount"];
                 options.UseAzurePlateFiles = ConfigReader<bool>.GetSetting("UseAzurePlateFiles");
+            });
+
+            services.AddCaching(options =>
+            {
+                options.RedisCacheConnectionString = ConfigurationManager.AppSettings["RedisConnectionString"];
+                options.UseCaching = ConfigReader<bool>.GetSetting("UseCaching");
+                options.SlidingExpiration = TimeSpan.Parse(ConfigurationManager.AppSettings["SlidingExpiration"]);
             });
 
             return services.BuildServiceProvider();

--- a/src/WWTMVC5/WWTMVC5.csproj
+++ b/src/WWTMVC5/WWTMVC5.csproj
@@ -1370,6 +1370,10 @@
       <Project>{e371698c-f67e-4da7-8545-1a7c984279c8}</Project>
       <Name>WWT.Azure</Name>
     </ProjectReference>
+    <ProjectReference Include="..\WWT.PlateFiles.Caching\WWT.PlateFiles.Caching.csproj">
+      <Project>{568de47a-de03-4b82-836a-c42c4c5a9f84}</Project>
+      <Name>WWT.PlateFiles.Caching</Name>
+    </ProjectReference>
     <ProjectReference Include="..\WWT.PlateFiles\WWT.PlateFiles.csproj">
       <Project>{fecd0629-586c-42c1-931a-3a06f18376ae}</Project>
       <Name>WWT.PlateFiles</Name>

--- a/src/WWTMVC5/Web.config
+++ b/src/WWTMVC5/Web.config
@@ -140,6 +140,11 @@ Content-Type: application/x-wt-->
     <add key="UseAzurePlateFiles" value="false"/>
     <add key="AzurePlateFileStorageAccount" value="https://127.0.0.1:10000/devstoreaccount1"/>
 
+    <!-- Caching settings -->
+    <add key="UseCaching" value="false" />
+    <add key="RedisConnectionString" value="" />
+    <add key="SlidingExpiration" value="1.00:00:00" />
+
     <!-- Overridden with Configuration Builders -->
     <add key="TourCache" value=""/>
     <add key="WWTTilesDir" value=""/>
@@ -208,6 +213,22 @@ Content-Type: application/x-wt-->
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Extensions.Caching.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
 				<bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
 			</dependentAssembly>
@@ -221,7 +242,7 @@ Content-Type: application/x-wt-->
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>

--- a/tests/WWT.PlateFiles.Caching.Tests/ExtensionTests.cs
+++ b/tests/WWT.PlateFiles.Caching.Tests/ExtensionTests.cs
@@ -1,0 +1,95 @@
+﻿using AutoFixture;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using StackExchange.Redis;
+using WWTWebservices;
+using Xunit;
+
+namespace WWT.PlateFiles.Caching.Tests
+{
+    public class ExtensionTests
+    {
+        private readonly Fixture _fixture;
+
+        public ExtensionTests()
+        {
+            _fixture = new Fixture();
+        }
+
+        [Fact]
+        public void NoCachingByDefault()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            var original = Substitute.For<IPlateTilePyramid>();
+            services.AddSingleton(original);
+
+            services.AddCaching(options =>
+            {
+                options.UseCaching = false;
+            });
+
+            using var provider = services.BuildServiceProvider();
+
+            // Act
+            var resolved = provider.GetRequiredService<IPlateTilePyramid>();
+
+            // Assert
+            Assert.Same(original, resolved);
+        }
+
+        [Fact]
+        public void InMemoryWhenNoRedisConnection()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            var original = Substitute.For<IPlateTilePyramid>();
+            services.AddSingleton(original);
+
+            services.AddCaching(options =>
+            {
+                options.UseCaching = true;
+            });
+
+            using var provider = services.BuildServiceProvider();
+
+            // Act
+            var resolved = provider.GetRequiredService<IPlateTilePyramid>();
+
+            // Assert
+            var inMemory = Assert.IsType<InMemoryCachedPlateTilePyramid>(resolved);
+
+            Assert.Same(original, inMemory.InnerPyramid);
+        }
+
+        [Fact]
+        public void RedisUsedWithConnectionString()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            var original = Substitute.For<IPlateTilePyramid>();
+            services.AddSingleton(original);
+
+            services.AddCaching(options =>
+            {
+                options.UseCaching = true;
+                options.RedisCacheConnectionString = _fixture.Create<string>();
+            });
+
+            services.AddSingleton(Substitute.For<IConnectionMultiplexer>());
+
+            using var provider = services.BuildServiceProvider();
+
+            // Act
+            var resolved = provider.GetRequiredService<IPlateTilePyramid>();
+
+            // Assert
+            var redis = Assert.IsType<RedisCachedPlateTilePyramid>(resolved);
+
+            Assert.Same(original, redis.InnerPyramid);
+        }
+    }
+}

--- a/tests/WWT.PlateFiles.Caching.Tests/InMemoryCachedPlateTilePyramidTests.cs
+++ b/tests/WWT.PlateFiles.Caching.Tests/InMemoryCachedPlateTilePyramidTests.cs
@@ -1,0 +1,93 @@
+﻿using AutofacContrib.NSubstitute;
+using AutoFixture;
+using NSubstitute;
+using System.IO;
+using System.Linq;
+using WWTWebservices;
+using Xunit;
+
+namespace WWT.PlateFiles.Caching.Tests
+{
+    public class InMemoryCachedPlateTilePyramidTests
+    {
+        private readonly Fixture _fixture;
+
+        public InMemoryCachedPlateTilePyramidTests()
+        {
+            _fixture = new Fixture();
+        }
+
+        [Fact]
+        public void CacheSanityPlate1()
+        {
+            // Arrange
+            using var mock = AutoSubstitute.Configure()
+                .MakeUnregisteredTypesPerLifetime()
+                .Build();
+
+            var level = _fixture.Create<int>();
+            var x = _fixture.Create<int>();
+            var y = _fixture.Create<int>();
+            var prefix = _fixture.Create<string>();
+            var name = _fixture.Create<string>();
+            var expected = _fixture.CreateMany<byte>(10).ToArray();
+
+            mock.Resolve<IPlateTilePyramid>().GetStream(prefix, name, level, x, y).Returns(new MemoryStream(expected));
+
+            var cached = mock.Resolve<InMemoryCachedPlateTilePyramid>();
+
+            // Act
+            using var result1 = cached.GetStream(prefix, name, level, x, y);
+            using var result2 = cached.GetStream(prefix, name, level, x, y);
+            using var result3 = cached.GetStream(prefix, name, level, x, y);
+
+            // Assert
+            var ms1 = Assert.IsType<MemoryStream>(result1);
+            var ms2 = Assert.IsType<MemoryStream>(result2);
+            var ms3 = Assert.IsType<MemoryStream>(result3);
+
+            Assert.Equal(expected, ms1.ToArray());
+            Assert.Equal(expected, ms2.ToArray());
+            Assert.Equal(expected, ms3.ToArray());
+
+            mock.Resolve<IPlateTilePyramid>().Received(1).GetStream(prefix, name, level, x, y);
+        }
+
+        [Fact]
+        public void CacheSanityPlate2()
+        {
+            // Arrange
+            using var mock = AutoSubstitute.Configure()
+                .MakeUnregisteredTypesPerLifetime()
+                .Build();
+
+            var level = _fixture.Create<int>();
+            var tag = _fixture.Create<int>();
+            var x = _fixture.Create<int>();
+            var y = _fixture.Create<int>();
+            var prefix = _fixture.Create<string>();
+            var name = _fixture.Create<string>();
+            var expected = _fixture.CreateMany<byte>(10).ToArray();
+
+            mock.Resolve<IPlateTilePyramid>().GetStream(prefix, name, tag, level, x, y).Returns(new MemoryStream(expected));
+
+            var cached = mock.Resolve<InMemoryCachedPlateTilePyramid>();
+
+            // Act
+            using var result1 = cached.GetStream(prefix, name, tag, level, x, y);
+            using var result2 = cached.GetStream(prefix, name, tag, level, x, y);
+            using var result3 = cached.GetStream(prefix, name, tag, level, x, y);
+
+            // Assert
+            var ms1 = Assert.IsType<MemoryStream>(result1);
+            var ms2 = Assert.IsType<MemoryStream>(result2);
+            var ms3 = Assert.IsType<MemoryStream>(result3);
+
+            Assert.Equal(expected, ms1.ToArray());
+            Assert.Equal(expected, ms2.ToArray());
+            Assert.Equal(expected, ms3.ToArray());
+
+            mock.Resolve<IPlateTilePyramid>().Received(1).GetStream(prefix, name, tag, level, x, y);
+        }
+    }
+}

--- a/tests/WWT.PlateFiles.Caching.Tests/RedisCachedPlateTilePyramidTests.cs
+++ b/tests/WWT.PlateFiles.Caching.Tests/RedisCachedPlateTilePyramidTests.cs
@@ -1,0 +1,151 @@
+﻿using AutofacContrib.NSubstitute;
+using AutoFixture;
+using NSubstitute;
+using StackExchange.Redis;
+using System;
+using System.IO;
+using System.Linq;
+using WWTWebservices;
+using Xunit;
+
+namespace WWT.PlateFiles.Caching.Tests
+{
+    public class RedisCachedPlateTilePyramidTests
+    {
+        private readonly Fixture _fixture;
+
+        public RedisCachedPlateTilePyramidTests()
+        {
+            _fixture = new Fixture();
+        }
+
+        [Fact]
+        public void CacheSanityPlate1()
+        {
+            // Arrange
+            using var mock = AutoSubstitute.Configure()
+                .MakeUnregisteredTypesPerLifetime()
+                .Build();
+
+            mock.Resolve<IConnectionMultiplexer>().GetDatabase().Returns(mock.Resolve<IDatabase>());
+
+            var level = _fixture.Create<int>();
+            var x = _fixture.Create<int>();
+            var y = _fixture.Create<int>();
+            var prefix = _fixture.Create<string>();
+            var name = _fixture.Create<string>();
+            var expected = _fixture.CreateMany<byte>(10).ToArray();
+
+            mock.Resolve<IPlateTilePyramid>().GetStream(prefix, name, level, x, y).Returns(new MemoryStream(expected));
+
+            var cached = mock.Resolve<RedisCachedPlateTilePyramid>();
+            var context = new CachedPlateTilePyramid.TileContext(null)
+            {
+                Level = level,
+                X = x,
+                Y = y,
+                PathPrefix = prefix,
+                PlateName = name,
+            };
+
+            // Act
+            using var result1 = cached.GetStream(prefix, name, level, x, y);
+
+            // Assert
+            var ms1 = Assert.IsType<MemoryStream>(result1);
+            Assert.Equal(expected, ms1.ToArray());
+
+            var key = context.GetKey();
+
+            mock.Resolve<IPlateTilePyramid>().Received(1).GetStream(prefix, name, level, x, y);
+            var d = mock.Resolve<IDatabase>();
+            d.Received(1).StringSet(key, result1.ToArray(), Arg.Any<TimeSpan>(), When.Always, CommandFlags.FireAndForget);
+        }
+
+        [Fact]
+        public void ReturnsCachedValue()
+        {
+            // Arrange
+            using var mock = AutoSubstitute.Configure()
+                .MakeUnregisteredTypesPerLifetime()
+                .Build();
+
+            var level = _fixture.Create<int>();
+            var x = _fixture.Create<int>();
+            var y = _fixture.Create<int>();
+            var prefix = _fixture.Create<string>();
+            var name = _fixture.Create<string>();
+            var expected = _fixture.CreateMany<byte>(10).ToArray();
+
+            var cached = mock.Resolve<RedisCachedPlateTilePyramid>();
+            var context = new CachedPlateTilePyramid.TileContext(null)
+            {
+                Level = level,
+                X = x,
+                Y = y,
+                PathPrefix = prefix,
+                PlateName = name,
+            };
+
+            var db = mock.Resolve<IDatabase>();
+            mock.Resolve<IConnectionMultiplexer>().GetDatabase().Returns(db);
+            var redisValue = RedisValue.CreateFrom(new MemoryStream(expected));
+            db.StringGet(context.GetKey()).Returns(redisValue);
+
+            // Act
+            using var result1 = cached.GetStream(prefix, name, level, x, y);
+
+            // Assert
+            var ms1 = Assert.IsType<MemoryStream>(result1);
+            Assert.Equal(expected, ms1.ToArray());
+
+            mock.Resolve<IPlateTilePyramid>().Received(0).GetStream(prefix, name, level, x, y);
+            db.DidNotReceiveWithAnyArgs().StringSet(Arg.Any<RedisKey>(), Arg.Any<RedisValue>(), Arg.Any<TimeSpan>(), When.Always, CommandFlags.FireAndForget);
+        }
+
+        [Fact]
+        public void CacheSanityPlate2()
+        {
+            // Arrange
+            using var mock = AutoSubstitute.Configure()
+                .MakeUnregisteredTypesPerLifetime()
+                .Build();
+
+            mock.Resolve<IConnectionMultiplexer>().GetDatabase().Returns(mock.Resolve<IDatabase>());
+
+            var level = _fixture.Create<int>();
+            var tag = _fixture.Create<int>();
+            var x = _fixture.Create<int>();
+            var y = _fixture.Create<int>();
+            var prefix = _fixture.Create<string>();
+            var name = _fixture.Create<string>();
+            var expected = _fixture.CreateMany<byte>(10).ToArray();
+
+            mock.Resolve<IPlateTilePyramid>().GetStream(prefix, name, tag, level, x, y).Returns(new MemoryStream(expected));
+
+            var cached = mock.Resolve<RedisCachedPlateTilePyramid>();
+            var context = new CachedPlateTilePyramid.TileContext(null)
+            {
+                Level = level,
+                Tag = tag,
+                X = x,
+                Y = y,
+                PathPrefix = prefix,
+                PlateName = name,
+            };
+
+            // Act
+            using var result1 = cached.GetStream(prefix, name, tag, level, x, y);
+
+            // Assert
+            var ms1 = Assert.IsType<MemoryStream>(result1);
+            Assert.Equal(expected, ms1.ToArray());
+
+            var key = context.GetKey();
+
+            mock.Resolve<IPlateTilePyramid>().Received(1).GetStream(prefix, name, tag, level, x, y);
+            var d = mock.Resolve<IDatabase>();
+            d.Received(1).StringSet(key, result1.ToArray(), Arg.Any<TimeSpan>(), When.Always, CommandFlags.FireAndForget);
+        }
+    }
+}

--- a/tests/WWT.PlateFiles.Caching.Tests/WWT.PlateFiles.Caching.Tests.csproj
+++ b/tests/WWT.PlateFiles.Caching.Tests/WWT.PlateFiles.Caching.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\WWT.PlateFiles.Caching\WWT.PlateFiles.Caching.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/wwt-website.sln
+++ b/wwt-website.sln
@@ -48,6 +48,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlateManager", "tools\Plate
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WWT.PlateFiles.Tests", "tests\WWT.PlateFiles.Tests\WWT.PlateFiles.Tests.csproj", "{D34D5F02-3A5B-446C-B02A-68DA5B9BC2AF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WWT.PlateFiles.Caching", "src\WWT.PlateFiles.Caching\WWT.PlateFiles.Caching.csproj", "{568DE47A-DE03-4B82-836A-C42C4C5A9F84}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WWT.PlateFiles.Caching.Tests", "tests\WWT.PlateFiles.Caching.Tests\WWT.PlateFiles.Caching.Tests.csproj", "{A34C0E73-F384-4FBA-AE89-3ECCC48892C1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -94,6 +98,14 @@ Global
 		{D34D5F02-3A5B-446C-B02A-68DA5B9BC2AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D34D5F02-3A5B-446C-B02A-68DA5B9BC2AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D34D5F02-3A5B-446C-B02A-68DA5B9BC2AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{568DE47A-DE03-4B82-836A-C42C4C5A9F84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{568DE47A-DE03-4B82-836A-C42C4C5A9F84}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{568DE47A-DE03-4B82-836A-C42C4C5A9F84}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{568DE47A-DE03-4B82-836A-C42C4C5A9F84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A34C0E73-F384-4FBA-AE89-3ECCC48892C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A34C0E73-F384-4FBA-AE89-3ECCC48892C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A34C0E73-F384-4FBA-AE89-3ECCC48892C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A34C0E73-F384-4FBA-AE89-3ECCC48892C1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -109,6 +121,8 @@ Global
 		{C5E54B43-A19F-4021-875C-E8769D89EB1A} = {EFF21404-6CEA-49EB-9402-C6643AC2564F}
 		{94CB88BE-875F-451D-8BB2-36327DA90708} = {45CC6DAC-BC15-4EEC-ABD3-34EC42E93221}
 		{D34D5F02-3A5B-446C-B02A-68DA5B9BC2AF} = {EFF21404-6CEA-49EB-9402-C6643AC2564F}
+		{568DE47A-DE03-4B82-836A-C42C4C5A9F84} = {F12286DB-AF41-4661-A1C6-EB3259CB9B41}
+		{A34C0E73-F384-4FBA-AE89-3ECCC48892C1} = {EFF21404-6CEA-49EB-9402-C6643AC2564F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {80DABDD3-0D48-43AD-893B-B09A38FCFC72}


### PR DESCRIPTION
This change adds an in-memory and redis cache layer.  This is configurable via web.config to turn caching on or off. If a redis connection string is available, it will cache there; otherwise, it will use an in-memory implementation.