### PR TITLE
Use Azure blobs as backend for thumbnail.aspx

### DIFF
--- a/src/WWT.Azure/AzureOptions.cs
+++ b/src/WWT.Azure/AzureOptions.cs
@@ -1,0 +1,11 @@
+﻿namespace WWT.Azure
+{
+    public class AzureOptions
+    {
+        /// <summary>
+        /// TODO: The current storage account is a classic storage account and managed identity is not supported
+        /// If the setting is a URL, we'll use managed identity. Otherwise, we'll expect it to be a connection string.
+        /// </summary>
+        public string StorageAccount { get; set; }
+    }
+}

--- a/src/WWT.Azure/AzurePlateTilePyramidOptions.cs
+++ b/src/WWT.Azure/AzurePlateTilePyramidOptions.cs
@@ -12,12 +12,6 @@ namespace WWT.Azure
 
         public bool OverwriteExisting { get; set; }
 
-        /// <summary>
-        /// TODO: The current storage account is a classic storage account and managed identity is not supported
-        /// If the setting is a URL, we'll use managed identity. Otherwise, we'll expect it to be a connection string.
-        /// </summary>
-        public string StorageAccount { get; set; }
-
         public bool UseAzurePlateFiles { get; set; }
     }
 }

--- a/src/WWT.Azure/AzureThumbnailAccessor.cs
+++ b/src/WWT.Azure/AzureThumbnailAccessor.cs
@@ -1,0 +1,40 @@
+﻿using Azure.Storage.Blobs;
+using System.IO;
+
+namespace WWT.Azure
+{
+    public class AzureThumbnailAccessor : IThumbnailAccessor
+    {
+        private readonly ThumbnailOptions _options;
+        private readonly BlobContainerClient _container;
+
+        public AzureThumbnailAccessor(ThumbnailOptions options, BlobServiceClient service)
+        {
+            _options = options;
+            _container = service.GetBlobContainerClient("thumbnails");
+        }
+
+        public Stream GetThumbnailStream(string name, string type)
+            => GetThumbnailStream(name) ?? GetThumbnailStream(type) ?? GetThumbnailStream(_options.Default);
+
+        private Stream GetThumbnailStream(string fileName)
+            => GetThumbnailStreamFromFile(fileName, "fromAssembly") ?? GetThumbnailStreamFromFile(fileName, "fromBackup");
+
+        private Stream GetThumbnailStreamFromFile(string fileName, string sub)
+        {
+            if (fileName is null)
+            {
+                return null;
+            }
+
+            var blob = _container.GetBlobClient($"{sub}/{fileName}.jpg");
+
+            if (blob.Exists())
+            {
+                return blob.OpenRead();
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/WWT.Azure/ThumbnailOptions.cs
+++ b/src/WWT.Azure/ThumbnailOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace WWT.Azure
+{
+    public class ThumbnailOptions
+    {
+        public string Default { get; set; } = "star";
+
+        public string ContainerName { get; set; } = "thumbnails";
+    }
+}

--- a/src/WWT.Providers/Providers/thumbnailProvider.cs
+++ b/src/WWT.Providers/Providers/thumbnailProvider.cs
@@ -2,14 +2,21 @@ using WWTThumbnails;
 
 namespace WWT.Providers
 {
-    public class thumbnailProvider : RequestProvider
+    public class ThumbnailProvider : RequestProvider
     {
+        private readonly IThumbnailAccessor _thumbnails;
+
+        public ThumbnailProvider(IThumbnailAccessor thumbnails)
+        {
+            _thumbnails = thumbnails;
+        }
+
         public override void Run(IWwtContext context)
         {
             string name = context.Request.Params["name"];
             string type = context.Request.Params["class"];
 
-            using (var s = WWTThumbnail.GetThumbnailStream(name, type))
+            using (var s = _thumbnails.GetThumbnailStream(name, type))
             {
                 s.CopyTo(context.Response.OutputStream);
                 context.Response.Flush();

--- a/src/WWTMVC5/Global.asax.cs
+++ b/src/WWTMVC5/Global.asax.cs
@@ -80,11 +80,20 @@ namespace WWTMVC5
                 options.WwtGalexDir = ConfigurationManager.AppSettings["WWTGALEXDIR"];
             });
 
-            services.AddAzureServices(options =>
-            {
-                options.StorageAccount = ConfigurationManager.AppSettings["AzurePlateFileStorageAccount"];
-                options.UseAzurePlateFiles = ConfigReader<bool>.GetSetting("UseAzurePlateFiles");
-            });
+            services
+                .AddAzureServices(options =>
+                {
+                    options.StorageAccount = ConfigurationManager.AppSettings["AzurePlateFileStorageAccount"];
+                })
+                .AddPlateFiles(options =>
+                {
+                    options.UseAzurePlateFiles = ConfigReader<bool>.GetSetting("UseAzurePlateFiles");
+                })
+                .AddThumbnails(options =>
+                {
+                    options.ContainerName = ConfigurationManager.AppSettings["ThumbnailContainer"];
+                    options.Default = ConfigurationManager.AppSettings["DefaultThumbnail"];
+                });
 
             services.AddCaching(options =>
             {

--- a/src/WWTMVC5/WWTWeb/thumbnail.aspx
+++ b/src/WWTMVC5/WWTWeb/thumbnail.aspx
@@ -2,5 +2,5 @@
 
 <%@ Import Namespace="WWT.Providers" %>
 <%
-	RequestProvider.Get<thumbnailProvider>().Run(this);
+	RequestProvider.Get<ThumbnailProvider>().Run(this);
 %>

--- a/src/WWTMVC5/Web.config
+++ b/src/WWTMVC5/Web.config
@@ -140,6 +140,10 @@ Content-Type: application/x-wt-->
     <add key="UseAzurePlateFiles" value="false"/>
     <add key="AzurePlateFileStorageAccount" value="https://127.0.0.1:10000/devstoreaccount1"/>
 
+    <!-- Thumbnail options -->
+    <add key="ThumbnailContainer" value="thumbnails"/>
+    <add key="DefaultThumbnail" value="star"/>
+
     <!-- Caching settings -->
     <add key="UseCaching" value="false" />
     <add key="RedisConnectionString" value="" />

--- a/src/WWTWebservices/IThumbnailAccessor.cs
+++ b/src/WWTWebservices/IThumbnailAccessor.cs
@@ -1,0 +1,9 @@
+﻿using System.IO;
+
+namespace WWT
+{
+    public interface IThumbnailAccessor
+    {
+        Stream GetThumbnailStream(string name, string type);
+    }
+}


### PR DESCRIPTION
This follows the current set up for thumbnails. There were two data sources:

- An assembly with some hard coded images
- A folder with some loose files

The assembly was searched first and then the folder. This is now handled by storing all on Azure, but in folders that are searched one after the other.

This also breaks out Azure configuration from platefiles so that thumbnails can use it as well.