### PR TITLE
Update moontoast* plate files to reflect changes to blob storage

### DIFF
--- a/src/WWT.Providers/Providers/moontoastProvider.cs
+++ b/src/WWT.Providers/Providers/moontoastProvider.cs
@@ -36,7 +36,7 @@ namespace WWT.Providers
             {
                 context.Response.ContentType = "image/png";
 
-                using (Stream s = _plateTiles.GetStream(wwtTilesDir, "L0X0Y0.plate", level, tileX, tileY))
+                using (Stream s = _plateTiles.GetStream(wwtTilesDir, "LROWAC_L0X0Y0.plate", level, tileX, tileY))
                 {
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
@@ -55,7 +55,7 @@ namespace WWT.Providers
                 int Y5 = tileY % powLev5Diff;
                 context.Response.ContentType = "image/png";
 
-                using (Stream s = _plateTiles.GetStream(wwtTilesDir, $"L3x{X32}y{Y32}.plate", L5, X5, Y5))
+                using (Stream s = _plateTiles.GetStream(wwtTilesDir, $"LROWAC_L3x{X32}y{Y32}.plate", L5, X5, Y5))
                 {
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();

--- a/src/WWT.Providers/Providers/moontoastdemProvider.cs
+++ b/src/WWT.Providers/Providers/moontoastdemProvider.cs
@@ -35,7 +35,7 @@ namespace WWT.Providers
             if (level < 7)
             {
                 context.Response.ContentType = "application/octet-stream";
-                using (Stream s = _plateTiles.GetStream(wwtDemDir, "L0X0Y0.plate", level, tileX, tileY))
+                using (Stream s = _plateTiles.GetStream(wwtDemDir, "moontoast_L0X0Y0.plate", level, tileX, tileY))
                 {
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
@@ -55,7 +55,7 @@ namespace WWT.Providers
 
                 context.Response.ContentType = "application/octet-stream";
 
-                using (Stream s = _plateTiles.GetStream(wwtDemDir, $"L3x{X32}y{Y32}.plate", L5, X5, Y5))
+                using (Stream s = _plateTiles.GetStream(wwtDemDir, $"moontoast_L3x{X32}y{Y32}.plate", L5, X5, Y5))
                 {
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();

--- a/tests/WWT.Providers.Tests/MoontoastProviderTests.cs
+++ b/tests/WWT.Providers.Tests/MoontoastProviderTests.cs
@@ -25,7 +25,7 @@ namespace WWT.Providers.Tests
 
             if (level < 7)
             {
-                return plateTiles.GetStream(prefix, "L0X0Y0.plate", level, x, y);
+                return plateTiles.GetStream(prefix, "LROWAC_L0X0Y0.plate", level, x, y);
             }
             else
             {
@@ -37,7 +37,7 @@ namespace WWT.Providers.Tests
                 int X5 = x % powLev5Diff;
                 int Y5 = y % powLev5Diff;
 
-                return plateTiles.GetStream(prefix, $"L3x{X32}y{Y32}.plate", L5, X5, Y5);
+                return plateTiles.GetStream(prefix, $"LROWAC_L3x{X32}y{Y32}.plate", L5, X5, Y5);
             }
         }
     }

--- a/tests/WWT.Providers.Tests/MoontoastdemProviderTests.cs
+++ b/tests/WWT.Providers.Tests/MoontoastdemProviderTests.cs
@@ -23,7 +23,7 @@ namespace WWT.Providers.Tests
         {
             if (level < 7)
             {
-                return plateTiles.GetStream(Path.Combine(Options.WWTDEMDir, "toast", "lola"), "L0X0Y0.plate", level, x, y);
+                return plateTiles.GetStream(Path.Combine(Options.WWTDEMDir, "toast", "lola"), "moontoast_L0X0Y0.plate", level, x, y);
             }
             else
             {
@@ -35,7 +35,7 @@ namespace WWT.Providers.Tests
                 int X5 = x % powLev5Diff;
                 int Y5 = y % powLev5Diff;
 
-                return plateTiles.GetStream(Path.Combine(Options.WWTDEMDir, "toast", "lola"), $"L3x{X32}y{Y32}.plate", L5, X5, Y5);
+                return plateTiles.GetStream(Path.Combine(Options.WWTDEMDir, "toast", "lola"), $"moontoast_L3x{X32}y{Y32}.plate", L5, X5, Y5);
             }
         }
     }


### PR DESCRIPTION
A prefix was added to these (documented in the CoreDataMap.docx) and this updates the providers to be aware of that.