### PR TITLE
Enable async RequestProviders

### DIFF
--- a/src/WWT.Providers/Providers/BingDemTile2Provider.cs
+++ b/src/WWT.Providers/Providers/BingDemTile2Provider.cs
@@ -2,13 +2,15 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
 {
     public class BingDemTile2Provider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -58,6 +60,8 @@ namespace WWT.Providers
             }
 
             context.Response.End();
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/BingDemTileProvider.cs
+++ b/src/WWT.Providers/Providers/BingDemTileProvider.cs
@@ -2,13 +2,15 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
 {
     public class BingDemTileProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -70,6 +72,8 @@ namespace WWT.Providers
             }
 
             context.Response.End();
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/Catalog2Provider.cs
+++ b/src/WWT.Providers/Providers/Catalog2Provider.cs
@@ -1,11 +1,13 @@
 ﻿using System.Configuration;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class Catalog2Provider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string etag = context.Request.Headers["If-None-Match"];
             string filename = "";
@@ -63,6 +65,8 @@ namespace WWT.Providers
                     context.Response.Status = "304 Not Modified";
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/CatalogProvider.cs
+++ b/src/WWT.Providers/Providers/CatalogProvider.cs
@@ -1,11 +1,13 @@
 ﻿using System.Configuration;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class CatalogProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string etag = context.Request.Headers["If-None-Match"];
             string filename = "";
@@ -62,6 +64,7 @@ namespace WWT.Providers
                 }
             }
 
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/DSSProvider.cs
+++ b/src/WWT.Providers/Providers/DSSProvider.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -14,7 +16,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -59,6 +61,8 @@ namespace WWT.Providers
                     context.Response.End();
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/DSSToastProvider.cs
+++ b/src/WWT.Providers/Providers/DSSToastProvider.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Configuration;
-using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -16,7 +16,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -61,6 +61,8 @@ namespace WWT.Providers
                     context.Response.End();
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/DemMarsEmptyProvider.cs
+++ b/src/WWT.Providers/Providers/DemMarsEmptyProvider.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
@@ -13,7 +15,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -42,11 +44,13 @@ namespace WWT.Providers
                 catch
                 {
                     context.Response.StatusCode = 404;
-                    return;
+                    return Task.CompletedTask;
                 }
             }
 
             context.Response.Write("ok");
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/DemProvider.cs
+++ b/src/WWT.Providers/Providers/DemProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
-using System.Configuration;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
@@ -13,7 +14,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -36,6 +37,8 @@ namespace WWT.Providers
             }
 
             context.Response.End();
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/DemTileProvider.cs
+++ b/src/WWT.Providers/Providers/DemTileProvider.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
@@ -12,7 +14,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -35,6 +37,8 @@ namespace WWT.Providers
             }
 
             context.Response.End();
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/DembathProvider.cs
+++ b/src/WWT.Providers/Providers/DembathProvider.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class DembathProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -23,6 +25,8 @@ namespace WWT.Providers
             {
                 context.Response.WriteFile(filename);
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/DustToastProvider.cs
+++ b/src/WWT.Providers/Providers/DustToastProvider.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -14,7 +16,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -33,6 +35,8 @@ namespace WWT.Providers
                     context.Response.End();
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/EarthBlendProvider.cs
+++ b/src/WWT.Providers/Providers/EarthBlendProvider.cs
@@ -3,6 +3,8 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -18,7 +20,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string wwtTilesDir = _options.WwtTilesDir;
             string DSSTileCache = _options.DSSTileCache;
@@ -32,7 +34,7 @@ namespace WWT.Providers
             {
                 context.Response.Write("No image");
                 context.Response.Close();
-                return;
+                return Task.CompletedTask;
             }
 
             string filename = $@"{DSSTileCache}\EarthBlend\level{level}\{tileY}\{tileX}_{tileY}.jpg";
@@ -48,7 +50,7 @@ namespace WWT.Providers
                     context.Response.OutputStream.Write(data, 0, length);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
             else if (level == 8)
@@ -74,7 +76,7 @@ namespace WWT.Providers
                     context.Response.OutputStream.Write(data, 0, length);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
 
             }
@@ -135,8 +137,7 @@ namespace WWT.Providers
                 }
 
                 context.Response.WriteFile(filename);
-                return;
-
+                return Task.CompletedTask;
             }
 
 
@@ -151,6 +152,8 @@ namespace WWT.Providers
             client.Dispose();
 
             context.Response.OutputStream.Write(dat, 0, dat.Length);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/EarthMerBathProvider.cs
+++ b/src/WWT.Providers/Providers/EarthMerBathProvider.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Configuration;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -16,7 +18,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -28,7 +30,7 @@ namespace WWT.Providers
             {
                 context.Response.Write("No image");
                 context.Response.Close();
-                return;
+                return Task.CompletedTask;
             }
 
             if (level < 8)
@@ -39,7 +41,7 @@ namespace WWT.Providers
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
             else if (level < 10)
@@ -60,7 +62,7 @@ namespace WWT.Providers
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
 
@@ -73,6 +75,7 @@ namespace WWT.Providers
             client.Dispose();
 
             context.Response.OutputStream.Write(dat, 0, dat.Length);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/ExcelAddinUpdateProvider.cs
+++ b/src/WWT.Providers/Providers/ExcelAddinUpdateProvider.cs
@@ -1,16 +1,20 @@
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class ExcelAddinUpdateProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             context.Response.AddHeader("Cache-Control", "no-cache");
             context.Response.Write("ClientVersion:");
             context.Response.WriteFile(context.MapPath(Path.Combine("..", "wwt2", "ExcelAddinVersion.txt")));
             context.Response.Write("\nUpdateUrl:");
             context.Response.WriteFile(context.MapPath(Path.Combine("..", "wwt2", "ExcelAddinUpdateUrl.txt")));
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/FixedAltitudeDemTileProvider.cs
+++ b/src/WWT.Providers/Providers/FixedAltitudeDemTileProvider.cs
@@ -1,10 +1,12 @@
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class FixedAltitudeDemTileProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -32,6 +34,8 @@ namespace WWT.Providers
             context.Response.OutputStream.Flush();
 
             context.Response.End();
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/Galex4FarProvider.cs
+++ b/src/WWT.Providers/Providers/Galex4FarProvider.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -14,7 +16,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -28,7 +30,7 @@ namespace WWT.Providers
                 context.Response.ContentType = "text/plain";
                 context.Response.Write("No image");
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
 
             if (level < 9)
@@ -42,7 +44,7 @@ namespace WWT.Providers
                         s.CopyTo(context.Response.OutputStream);
                         context.Response.Flush();
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
                 }
                 catch
@@ -51,7 +53,7 @@ namespace WWT.Providers
                     context.Response.ContentType = "text/plain";
                     context.Response.Write("No image");
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
             else
@@ -74,7 +76,7 @@ namespace WWT.Providers
                         s.CopyTo(context.Response.OutputStream);
                         context.Response.Flush();
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
                 }
                 catch
@@ -83,7 +85,7 @@ namespace WWT.Providers
                     context.Response.ContentType = "text/plain";
                     context.Response.Write("No image");
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/WWT.Providers/Providers/Galex4NearProvider.cs
+++ b/src/WWT.Providers/Providers/Galex4NearProvider.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -14,7 +16,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -28,7 +30,7 @@ namespace WWT.Providers
                 context.Response.ContentType = "text/plain";
                 context.Response.Write("No image");
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
 
             if (level < 9)
@@ -42,7 +44,7 @@ namespace WWT.Providers
                         s.CopyTo(context.Response.OutputStream);
                         context.Response.Flush();
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
                 }
                 catch
@@ -51,7 +53,7 @@ namespace WWT.Providers
                     context.Response.ContentType = "text/plain";
                     context.Response.Write("No image");
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
             else
@@ -74,7 +76,7 @@ namespace WWT.Providers
                         s.CopyTo(context.Response.OutputStream);
                         context.Response.Flush();
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
                 }
                 catch
@@ -83,7 +85,7 @@ namespace WWT.Providers
                     context.Response.ContentType = "text/plain";
                     context.Response.Write("No image");
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/WWT.Providers/Providers/GalexToastProvider.cs
+++ b/src/WWT.Providers/Providers/GalexToastProvider.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -14,7 +16,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -28,7 +30,7 @@ namespace WWT.Providers
                 context.Response.ContentType = "text/plain";
                 context.Response.Write("No image");
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
 
             if (level < 9)
@@ -42,7 +44,7 @@ namespace WWT.Providers
                         s.CopyTo(context.Response.OutputStream);
                         context.Response.Flush();
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
                 }
                 catch
@@ -51,7 +53,7 @@ namespace WWT.Providers
                     context.Response.ContentType = "text/plain";
                     context.Response.Write("No image");
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
             else
@@ -73,7 +75,7 @@ namespace WWT.Providers
                         s.CopyTo(context.Response.OutputStream);
                         context.Response.Flush();
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
                 }
                 catch
@@ -82,7 +84,7 @@ namespace WWT.Providers
                     context.Response.ContentType = "text/plain";
                     context.Response.Write("No image");
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/WWT.Providers/Providers/GetAuthorThumbnailProvider.cs
+++ b/src/WWT.Providers/Providers/GetAuthorThumbnailProvider.cs
@@ -1,13 +1,15 @@
 using System;
 using System.Configuration;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
 {
     public class GetAuthorThumbnailProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string guid;
             if (context.Request.Params["GUID"] != null)
@@ -17,7 +19,7 @@ namespace WWT.Providers
             else
             {
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
             string tourcache = ConfigurationManager.AppSettings["WWTTOURCACHE"];
             string localDir = tourcache;
@@ -49,7 +51,7 @@ namespace WWT.Providers
                 {
                     context.Response.ContentType = "image/png";
                     context.Response.WriteFile(localfilename);
-                    return;
+                    return Task.CompletedTask;
                 }
                 catch
                 {
@@ -59,6 +61,8 @@ namespace WWT.Providers
             {
                 context.Response.Status = "404 Not Found";
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/GetHostNameProvider.cs
+++ b/src/WWT.Providers/Providers/GetHostNameProvider.cs
@@ -1,10 +1,14 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace WWT.Providers
 {
     public class GetHostNameProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             context.Response.Write(context.MachineName);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/GetTileProvider.cs
+++ b/src/WWT.Providers/Providers/GetTileProvider.cs
@@ -1,13 +1,15 @@
 using System;
 using System.Configuration;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
 {
     public class GetTileProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -24,10 +26,11 @@ namespace WWT.Providers
             if (!File.Exists(filename))
             {
                 context.Response.StatusCode = 404;
-                return;
+                return Task.CompletedTask;
             }
 
             context.Response.WriteFile(filename);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/GetTourFileProvider.cs
+++ b/src/WWT.Providers/Providers/GetTourFileProvider.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -14,7 +16,7 @@ namespace WWT.Providers
             _hasher = hasher;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string path = context.MapPath(@"TourCache");
 
@@ -56,6 +58,8 @@ namespace WWT.Providers
             {
                 context.Response.Write(e.Message);
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/GetTourListProvider.cs
+++ b/src/WWT.Providers/Providers/GetTourListProvider.cs
@@ -1,3 +1,6 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace WWT.Providers
 {
     public class GetTourListProvider : GetTourList
@@ -7,7 +10,7 @@ namespace WWT.Providers
         {
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string etag = context.Request.Headers["If-None-Match"];
 
@@ -37,6 +40,8 @@ namespace WWT.Providers
                 }
             }
             context.Response.End();
+
+            return Task.CompletedTask;
         }
 
         protected override string SqlCommandString => "Select CategoryId, ParentCatID, Name, CatThumbnailUrl from TourCategories where ParentCatId = ";

--- a/src/WWT.Providers/Providers/GetTourProvider.cs
+++ b/src/WWT.Providers/Providers/GetTourProvider.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Configuration;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class GetTourProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string guid;
             if (context.Request.Params["GUID"] != null)
@@ -16,7 +18,7 @@ namespace WWT.Providers
             else
             {
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
             string tourcache = ConfigurationManager.AppSettings["WWTTOURCACHE"];
             string localDir = tourcache;
@@ -47,7 +49,7 @@ namespace WWT.Providers
                 {
                     context.Response.ContentType = "application/x-wtt";
                     context.Response.WriteFile(localfilename);
-                    return;
+                    return Task.CompletedTask;
                 }
                 catch
                 {
@@ -57,6 +59,8 @@ namespace WWT.Providers
             {
                 context.Response.Status = "404 Not Found";
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/GetTourThumbnailProvider.cs
+++ b/src/WWT.Providers/Providers/GetTourThumbnailProvider.cs
@@ -1,13 +1,15 @@
 using System;
 using System.Configuration;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
 {
     public class GetTourThumbnailProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string guid;
             if (context.Request.Params["GUID"] != null)
@@ -17,7 +19,7 @@ namespace WWT.Providers
             else
             {
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
             string tourcache = ConfigurationManager.AppSettings["WWTTOURCACHE"];
             string localDir = tourcache;
@@ -51,7 +53,7 @@ namespace WWT.Providers
                 {
                     context.Response.ContentType = "image/png";
                     context.Response.WriteFile(localfilename);
-                    return;
+                    return Task.CompletedTask;
                 }
                 catch
                 {
@@ -61,6 +63,8 @@ namespace WWT.Providers
             {
                 context.Response.Status = "404 Not Found";
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/GetToursProvider.cs
+++ b/src/WWT.Providers/Providers/GetToursProvider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Xml;
 using WWTWebservices;
 
@@ -12,10 +14,9 @@ namespace WWT.Providers
         {
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string etag = context.Request.Headers["If-None-Match"];
-
 
             context.Response.ClearHeaders();
             context.Response.Clear();
@@ -42,6 +43,8 @@ namespace WWT.Providers
                 }
             }
             context.Response.End();
+
+            return Task.CompletedTask;
         }
 
         protected override void LoadTourFromRow(DataRow dr, Tour tr)

--- a/src/WWT.Providers/Providers/GlimpseProvider.cs
+++ b/src/WWT.Providers/Providers/GlimpseProvider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -15,7 +17,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -29,7 +31,7 @@ namespace WWT.Providers
                 context.Response.ContentType = "text/plain";
                 context.Response.Write("No image");
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
 
             if (level < 11)
@@ -43,7 +45,7 @@ namespace WWT.Providers
                         s.CopyTo(context.Response.OutputStream);
                         context.Response.Flush();
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
                 }
                 catch
@@ -52,7 +54,7 @@ namespace WWT.Providers
                     context.Response.ContentType = "text/plain";
                     context.Response.Write("No image");
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
 
             }
@@ -78,7 +80,7 @@ namespace WWT.Providers
                         s.CopyTo(context.Response.OutputStream);
                         context.Response.Flush();
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
                 }
                 catch
@@ -87,7 +89,7 @@ namespace WWT.Providers
                     context.Response.ContentType = "text/plain";
                     context.Response.Write("No image");
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/WWT.Providers/Providers/Goto2Provider.cs
+++ b/src/WWT.Providers/Providers/Goto2Provider.cs
@@ -1,16 +1,18 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Web;
 
 namespace WWT.Providers
 {
     public class Goto2Provider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             if (context.Request.ContainsCookie("alphakey") && context.Request.Params["wtml"] == null)
             {
                 context.Response.Redirect("http://www.worldwidetelescope.org/webclient/default.aspx?wtml=" + HttpUtility.UrlEncode(context.Request.Url.ToString() + "&wtml=true"));
-                return;
+                return Task.CompletedTask;
             }
 
             string name = context.Request.Params["object"];
@@ -32,6 +34,8 @@ namespace WWT.Providers
 
             string xml = string.Format("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Folder Group=\"Goto\">\n<Place Name=\"{0}\" RA=\"{1}\" Dec=\"{2}\" ZoomLevel=\"{3}\" DataSetType=\"Sky\"/>\n</Folder>", name, ra, dec, zoom);
             context.Response.Write(xml);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/GotoProvider.cs
+++ b/src/WWT.Providers/Providers/GotoProvider.cs
@@ -1,16 +1,18 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Web;
 
 namespace WWT.Providers
 {
     public class GotoProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             if (!context.Request.ContainsCookie("fullclient") && context.Request.Params["wtml"] == null)
             {
                 context.Response.Redirect("http://www.worldwidetelescope.org/webclient/default.aspx?wtml=" + HttpUtility.UrlEncode(context.Request.Url.ToString() + "&wtml=true"));
-                return;
+                return Task.CompletedTask;
             }
 
             string name = context.Request.Params["object"];
@@ -32,6 +34,8 @@ namespace WWT.Providers
 
             string xml = string.Format("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Folder Group=\"Goto\">\n<Place Name=\"{0}\" RA=\"{1}\" Dec=\"{2}\" ZoomLevel=\"{3}\" DataSetType=\"Sky\"/>\n</Folder>", name, ra, dec, zoom);
             context.Response.Write(xml);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/HiriseDem2Provider.cs
+++ b/src/WWT.Providers/Providers/HiriseDem2Provider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -11,7 +13,7 @@ namespace WWT.Providers
         {
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -32,13 +34,13 @@ namespace WWT.Providers
                         context.Response.ContentType = "text/plain";
                         context.Response.Write("No image");
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
 
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
             else
@@ -51,13 +53,13 @@ namespace WWT.Providers
                         context.Response.ContentType = "text/plain";
                         context.Response.Write("No image");
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
 
                     ss.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/WWT.Providers/Providers/HiriseDem3Provider.cs
+++ b/src/WWT.Providers/Providers/HiriseDem3Provider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -15,7 +17,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -36,17 +38,19 @@ namespace WWT.Providers
                         context.Response.ContentType = "text/plain";
                         context.Response.Write("No image");
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
 
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
 
             context.Response.WriteFile(filename);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/HiriseDemProvider.cs
+++ b/src/WWT.Providers/Providers/HiriseDemProvider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -15,7 +17,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -36,17 +38,19 @@ namespace WWT.Providers
                         context.Response.ContentType = "text/plain";
                         context.Response.Write("No image");
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
 
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
 
             context.Response.WriteFile(filename);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/HiriseProvider.cs
+++ b/src/WWT.Providers/Providers/HiriseProvider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -13,7 +15,7 @@ namespace WWT.Providers
             _plateTiles = plateTiles;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -35,15 +37,17 @@ namespace WWT.Providers
                         context.Response.ContentType = "text/plain";
                         context.Response.Write("No image");
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
 
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/JupiterProvider.cs
+++ b/src/WWT.Providers/Providers/JupiterProvider.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -14,7 +16,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -33,6 +35,8 @@ namespace WWT.Providers
                     context.Response.End();
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/MandelProvider.cs
+++ b/src/WWT.Providers/Providers/MandelProvider.cs
@@ -3,6 +3,8 @@ using System.Collections;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
@@ -15,7 +17,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -127,6 +129,8 @@ namespace WWT.Providers
             }
 
             context.Response.End();
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/MarsHiriseProvider.cs
+++ b/src/WWT.Providers/Providers/MarsHiriseProvider.cs
@@ -2,6 +2,8 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -17,7 +19,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -30,7 +32,7 @@ namespace WWT.Providers
             if (level > 17)
             {
                 context.Response.StatusCode = 404;
-                return;
+                return Task.CompletedTask;
             }
 
             using (Bitmap output = new Bitmap(256, 256))
@@ -96,6 +98,8 @@ namespace WWT.Providers
 
                 output.Save(context.Response.OutputStream, ImageFormat.Png);
             }
+
+            return Task.CompletedTask;
         }
 
         private Stream LoadHiRise(int level, int tileX, int tileY, int id)

--- a/src/WWT.Providers/Providers/MarsMocProvider.cs
+++ b/src/WWT.Providers/Providers/MarsMocProvider.cs
@@ -2,6 +2,8 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -17,7 +19,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -34,7 +36,7 @@ namespace WWT.Providers
                     if (level > 14)
                     {
                         context.Response.StatusCode = 404;
-                        return;
+                        return Task.CompletedTask;
                     }
 
                     int ll = level;
@@ -90,6 +92,8 @@ namespace WWT.Providers
 
                 output.Save(context.Response.OutputStream, ImageFormat.Png);
             }
+
+            return Task.CompletedTask;
         }
 
         private Stream LoadMoc(int level, int tileX, int tileY)

--- a/src/WWT.Providers/Providers/MartianTile2Provider.cs
+++ b/src/WWT.Providers/Providers/MartianTile2Provider.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Configuration;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -16,7 +18,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -39,13 +41,13 @@ namespace WWT.Providers
                                 context.Response.ContentType = "text/plain";
                                 context.Response.Write("No image");
                                 context.Response.End();
-                                return;
+                                return Task.CompletedTask;
                             }
 
                             s.CopyTo(context.Response.OutputStream);
                             context.Response.Flush();
                             context.Response.End();
-                            return;
+                            return Task.CompletedTask;
                         }
                     }
                     break;
@@ -67,12 +69,12 @@ namespace WWT.Providers
                                 context.Response.ContentType = "text/plain";
                                 context.Response.Write("No image");
                                 context.Response.End();
-                                return;
+                                return Task.CompletedTask;
                             }
                             s.CopyTo(context.Response.OutputStream);
                             context.Response.Flush();
                             context.Response.End();
-                            return;
+                            return Task.CompletedTask;
                         }
                     }
 
@@ -92,13 +94,13 @@ namespace WWT.Providers
                                 context.Response.ContentType = "text/plain";
                                 context.Response.Write("No image");
                                 context.Response.End();
-                                return;
+                                return Task.CompletedTask;
                             }
 
                             s.CopyTo(context.Response.OutputStream);
                             context.Response.Flush();
                             context.Response.End();
-                            return;
+                            return Task.CompletedTask;
                         }
                     }
                     break;
@@ -132,6 +134,8 @@ namespace WWT.Providers
             {
                 context.Response.WriteFile(filename);
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/MartianTileEmptyProvider.cs
+++ b/src/WWT.Providers/Providers/MartianTileEmptyProvider.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
@@ -13,7 +15,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -78,11 +80,12 @@ namespace WWT.Providers
                 {
                     context.Response.StatusCode = 404;
                     context.Response.Write("Not Found");
-                    return;
+                    return Task.CompletedTask;
                 }
             }
 
             context.Response.Write("OK");
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/MartianTileProvider.cs
+++ b/src/WWT.Providers/Providers/MartianTileProvider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
@@ -12,7 +14,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -66,6 +68,8 @@ namespace WWT.Providers
             {
                 context.Response.WriteFile(filename);
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/MipsgalProvider.cs
+++ b/src/WWT.Providers/Providers/MipsgalProvider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -15,7 +17,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -29,7 +31,7 @@ namespace WWT.Providers
                 context.Response.ContentType = "text/plain";
                 context.Response.Write("No image");
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
 
             if (level < 11)
@@ -42,7 +44,7 @@ namespace WWT.Providers
                         s.CopyTo(context.Response.OutputStream);
                         context.Response.Flush();
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
                 }
                 catch
@@ -51,7 +53,7 @@ namespace WWT.Providers
                     context.Response.ContentType = "text/plain";
                     context.Response.Write("No image");
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
             else
@@ -75,7 +77,7 @@ namespace WWT.Providers
                         s.CopyTo(context.Response.OutputStream);
                         context.Response.Flush();
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
                 }
                 catch
@@ -84,7 +86,7 @@ namespace WWT.Providers
                     context.Response.ContentType = "text/plain";
                     context.Response.Write("No image");
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/WWT.Providers/Providers/PostMarsProvider.cs
+++ b/src/WWT.Providers/Providers/PostMarsProvider.cs
@@ -1,10 +1,14 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace WWT.Providers
 {
     public class PostMarsProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             context.Response.Write("OK");
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/PostRatingFeedbackProvider.cs
+++ b/src/WWT.Providers/Providers/PostRatingFeedbackProvider.cs
@@ -2,12 +2,14 @@ using System;
 using System.Configuration;
 using System.Data;
 using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class PostRatingFeedbackProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             context.Response.ClearHeaders();
             context.Response.Clear();
@@ -28,6 +30,7 @@ namespace WWT.Providers
             {
             }
             context.Response.End();
+            return Task.CompletedTask;
         }
 
         private static SqlConnection GetConnectionWWTTours()

--- a/src/WWT.Providers/Providers/RassToastProvider.cs
+++ b/src/WWT.Providers/Providers/RassToastProvider.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -14,7 +16,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -33,6 +35,8 @@ namespace WWT.Providers
                     context.Response.End();
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/SDSS12ToastProvider.cs
+++ b/src/WWT.Providers/Providers/SDSS12ToastProvider.cs
@@ -3,6 +3,8 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -18,14 +20,14 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             if (context.Request.UserAgent.ToLower().Contains("wget"))
             {
 
                 context.Response.Write("You are not allowed to bulk download imagery thru the tile service. Please contact wwtpage@microsoft.com for more information.");
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
 
             string query = context.Request.Params["Q"];
@@ -46,14 +48,14 @@ namespace WWT.Providers
             {
                 context.Response.Write("Invalid query string.");
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
 
             if (level > 14)
             {
                 context.Response.Write("No image");
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
 
             if (level < 8)
@@ -68,13 +70,13 @@ namespace WWT.Providers
                         context.Response.ContentType = "text/plain";
                         context.Response.Write("No image");
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
 
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
 
@@ -85,7 +87,7 @@ namespace WWT.Providers
                 try
                 {
                     context.Response.WriteFile(filename);
-                    return;
+                    return Task.CompletedTask;
                 }
                 catch
                 {
@@ -152,6 +154,8 @@ namespace WWT.Providers
             }
 
             context.Response.End();
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/SDSSToast.offlineProvider.cs
+++ b/src/WWT.Providers/Providers/SDSSToast.offlineProvider.cs
@@ -1,10 +1,14 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace WWT.Providers
 {
     public class SDSSToastOfflineProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             context.Response.Write("Hello");
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/SDSSToast2Provider.cs
+++ b/src/WWT.Providers/Providers/SDSSToast2Provider.cs
@@ -3,6 +3,8 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -18,7 +20,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -30,7 +32,7 @@ namespace WWT.Providers
             {
                 context.Response.Write("No image");
                 context.Response.Close();
-                return;
+                return Task.CompletedTask;
             }
 
             if (level < 9)
@@ -42,7 +44,7 @@ namespace WWT.Providers
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
 
@@ -70,7 +72,7 @@ namespace WWT.Providers
                 try
                 {
                     context.Response.WriteFile(filename);
-                    return;
+                    return Task.CompletedTask;
                 }
                 catch
                 {
@@ -149,6 +151,8 @@ namespace WWT.Providers
             }
 
             context.Response.End();
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/SDSSToastProvider.cs
+++ b/src/WWT.Providers/Providers/SDSSToastProvider.cs
@@ -3,6 +3,8 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -18,13 +20,13 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             if (context.Request.UserAgent.ToLower().Contains("wget"))
             {
                 context.Response.Write("You are not allowed to bulk download imagery thru the tile service. Please contact wwtpage@microsoft.com for more information.");
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
 
             string query = context.Request.Params["Q"];
@@ -45,7 +47,7 @@ namespace WWT.Providers
             {
                 context.Response.Write("Invalid query string.");
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
 
             string wwtTilesDir = _options.WwtTilesDir;
@@ -54,7 +56,7 @@ namespace WWT.Providers
             {
                 context.Response.Write("No image");
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
 
             if (level < 9)
@@ -69,13 +71,13 @@ namespace WWT.Providers
                         context.Response.ContentType = "text/plain";
                         context.Response.Write("No image");
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
 
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
 
@@ -85,7 +87,7 @@ namespace WWT.Providers
                 try
                 {
                     context.Response.WriteFile(filename);
-                    return;
+                    return Task.CompletedTask;
                 }
                 catch
                 {
@@ -161,6 +163,7 @@ namespace WWT.Providers
             }
 
             context.Response.End();
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/ShowImage2Provider.cs
+++ b/src/WWT.Providers/Providers/ShowImage2Provider.cs
@@ -1,16 +1,18 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Web;
 
 namespace WWT.Providers
 {
     public class ShowImage2Provider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             if (context.Request.ContainsCookie("alphakey"))
             {
                 context.Response.Redirect("http://www.worldwidetelescope.org/webclient/default.aspx?Wtml=" + HttpUtility.UrlEncode(context.Request.Url.ToString() + "&wtml=true"));
-                return;
+                return Task.CompletedTask;
             }
 
             if (context.Request.Params["debug"] != null)
@@ -101,6 +103,8 @@ namespace WWT.Providers
             string xml = string.Format("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Folder Name=\"{0}\" Group=\"{14}\">\n<Place Name=\"{0}\" RA=\"{1}\" Dec=\"{2}\" ZoomLevel=\"{3}\" DataSetType=\"Sky\" Opacity=\"100\" Thumbnail=\"{10}\" Constellation=\"\">\n <ForegroundImageSet>\n <ImageSet DataSetType=\"Sky\" BandPass=\"Visible\" Url=\"{8}\" TileLevels=\"0\" WidthFactor=\"2\" Rotation=\"{5}\" Projection=\"SkyImage\" FileType=\".tif\" CenterY=\"{2}\" CenterX=\"{9}\" BottomsUp=\"{13}\" OffsetX=\"{6}\" OffsetY=\"{7}\" BaseTileLevel=\"0\" BaseDegreesPerTile=\"{4}\">\n<Credits>{11}</Credits>\n<CreditsUrl>{12}</CreditsUrl>\n</ImageSet>\n</ForegroundImageSet>\n</Place>\n</Folder>", name, ra / 15, dec, zoom, scale, rotation, x, y, url, ra, thumb, credits, creditsUrl, reverseparity, bgoto ? "Goto" : "Search");
 
             context.Response.Write(xml);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/ShowImageProvider.cs
+++ b/src/WWT.Providers/Providers/ShowImageProvider.cs
@@ -1,16 +1,18 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Web;
 
 namespace WWT.Providers
 {
     public class ShowImageProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             if (!context.Request.ContainsCookie("fullclient") && context.Request.Params["wtml"] == null)
             {
                 context.Response.Redirect("http://www.worldwidetelescope.org/webclient/default.aspx?wtml=" + HttpUtility.UrlEncode(context.Request.Url.ToString().Replace(",", "-") + "&wtml=true"));
-                return;
+                return Task.CompletedTask;
             }
 
             if (context.Request.Params["debug"] != null)
@@ -105,6 +107,8 @@ namespace WWT.Providers
             string xml = string.Format("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Folder Name=\"{0}\" Group=\"{14}\">\n<Place Name=\"{0}\" RA=\"{1}\" Dec=\"{2}\" ZoomLevel=\"{3}\" DataSetType=\"Sky\" Opacity=\"100\" Thumbnail=\"{10}\" Constellation=\"\">\n <ForegroundImageSet>\n <ImageSet DataSetType=\"Sky\" BandPass=\"Visible\" Url=\"{8}\" TileLevels=\"0\" WidthFactor=\"2\" Rotation=\"{5}\" Projection=\"SkyImage\" FileType=\".tif\" CenterY=\"{2}\" CenterX=\"{9}\" BottomsUp=\"{13}\" OffsetX=\"{6}\" OffsetY=\"{7}\" BaseTileLevel=\"0\" BaseDegreesPerTile=\"{4}\">\n<Credits>{11}</Credits>\n<CreditsUrl>{12}</CreditsUrl>\n</ImageSet>\n</ForegroundImageSet>\n</Place>\n</Folder>", name, ra / 15, dec, zoom, scale, rotation, x, y, url, ra, thumb, credits, creditsUrl, reverseparity, bgoto ? "Goto" : "Search");
 
             context.Response.Write(xml);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/StarChartProvider.cs
+++ b/src/WWT.Providers/Providers/StarChartProvider.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class StarChartProvider : StarChart
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             double lat = double.Parse(context.Request.Params["lat"]);
             double lng = double.Parse(context.Request.Params["lng"]);
@@ -36,6 +38,8 @@ namespace WWT.Providers
             Bitmap chart = GetChart(lat, lng, time, ra, dec, width, height);
             chart.Save(context.Response.OutputStream, ImageFormat.Png);
             chart.Dispose();
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/TileImageProvider.cs
+++ b/src/WWT.Providers/Providers/TileImageProvider.cs
@@ -3,6 +3,8 @@ using System.Configuration;
 using System.Drawing;
 using System.IO;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -16,7 +18,7 @@ namespace WWT.Providers
             _hasher = hasher;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             {
                 //if (context.Request.Cookies["alphakey"] != null && context.Request.Params["wtml"] == null)
@@ -204,6 +206,8 @@ namespace WWT.Providers
 
                     context.Response.Write(xml);
                 }
+
+                return Task.CompletedTask;
             }
         }
     }

--- a/src/WWT.Providers/Providers/TwoMASSOctProvider.cs
+++ b/src/WWT.Providers/Providers/TwoMASSOctProvider.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Configuration;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -16,7 +18,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -35,6 +37,8 @@ namespace WWT.Providers
                     context.Response.End();
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/TwoMassToastProvider.cs
+++ b/src/WWT.Providers/Providers/TwoMassToastProvider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -15,7 +17,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -29,7 +31,7 @@ namespace WWT.Providers
                 context.Response.ContentType = "text/plain";
                 context.Response.Write("No image");
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
             else
             {
@@ -42,7 +44,7 @@ namespace WWT.Providers
                         s.CopyTo(context.Response.OutputStream);
                         context.Response.Flush();
                         context.Response.End();
-                        return;
+                        return Task.CompletedTask;
                     }
                 }
                 catch
@@ -51,9 +53,8 @@ namespace WWT.Providers
                     context.Response.ContentType = "text/plain";
                     context.Response.Write("No image");
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
-
             }
         }
     }

--- a/src/WWT.Providers/Providers/TychoOctProvider.cs
+++ b/src/WWT.Providers/Providers/TychoOctProvider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -15,7 +17,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -27,13 +29,15 @@ namespace WWT.Providers
             {
                 context.Response.ContentType = "image/png";
 
-                using (Stream s = _plateTiles.GetStream(_options.WwtTilesDir,  $"tychotoast.plate", level, tileX, tileY))
+                using (Stream s = _plateTiles.GetStream(_options.WwtTilesDir, $"tychotoast.plate", level, tileX, tileY))
                 {
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/WMSEarthTodayProvider.cs
+++ b/src/WWT.Providers/Providers/WMSEarthTodayProvider.cs
@@ -3,6 +3,8 @@ using System.Configuration;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -16,7 +18,7 @@ namespace WWT.Providers
             _hasher = hasher;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             bool debug = context.Request.Params["debug"] != null;
@@ -36,17 +38,15 @@ namespace WWT.Providers
             {
                 context.Response.Write("No image");
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
-
-
 
             if (File.Exists(filename) && DateTime.Now.Subtract(File.GetLastWriteTime(filename)).TotalHours < 12)
             {
                 try
                 {
                     context.Response.WriteFile(filename);
-                    return;
+                    return Task.CompletedTask;
                 }
                 catch
                 {
@@ -65,7 +65,7 @@ namespace WWT.Providers
                     context.Response.ContentType = "text/plain";
                     context.Response.Write(sdim.LoadImage(wmsUrl, true, ImageSource.WmsJpl));
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
                 sdim.LoadImage(wmsUrl, false, ImageSource.WmsJpl);
                 sdim.Lock();
@@ -117,6 +117,7 @@ namespace WWT.Providers
             }
 
             context.Response.End();
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/WMSMoonProvider.cs
+++ b/src/WWT.Providers/Providers/WMSMoonProvider.cs
@@ -2,6 +2,8 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -15,7 +17,7 @@ namespace WWT.Providers
             _hasher = hasher;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             bool debug = context.Request.Params["debug"] != null;
@@ -34,7 +36,7 @@ namespace WWT.Providers
             {
                 context.Response.Write("No image");
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
 
             if (File.Exists(filename))
@@ -42,7 +44,7 @@ namespace WWT.Providers
                 try
                 {
                     context.Response.WriteFile(filename);
-                    return;
+                    return Task.CompletedTask;
                 }
                 catch
                 {
@@ -62,7 +64,7 @@ namespace WWT.Providers
                     context.Response.ContentType = "text/plain";
                     context.Response.Write(sdim.LoadImage(wmsUrl, true));
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
                 sdim.LoadImage(wmsUrl, false);
                 sdim.Lock();
@@ -116,6 +118,7 @@ namespace WWT.Providers
             }
 
             context.Response.End();
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/WMSToastProvider.cs
+++ b/src/WWT.Providers/Providers/WMSToastProvider.cs
@@ -3,6 +3,8 @@ using System.Configuration;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -16,7 +18,7 @@ namespace WWT.Providers
             _hasher = hasher;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             bool debug = context.Request.Params["debug"] != null;
@@ -38,7 +40,7 @@ namespace WWT.Providers
             {
                 context.Response.Write("No image");
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
 
 
@@ -48,16 +50,14 @@ namespace WWT.Providers
                 try
                 {
                     context.Response.WriteFile(filename);
-                    return;
+                    return Task.CompletedTask;
                 }
                 catch
                 {
                 }
             }
             else
-
             {
-
                 ToastTileMap map = new ToastTileMap(level, tileX, tileY);
 
                 Int32 sqSide = 256;
@@ -72,7 +72,7 @@ namespace WWT.Providers
                     context.Response.ContentType = "text/plain";
                     context.Response.Write(sdim.LoadImage(wmsUrl, true, ImageSource.MarsAsu));
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
                 sdim.LoadImage(wmsUrl, false, ImageSource.MarsAsu);
                 sdim.Lock();
@@ -124,6 +124,7 @@ namespace WWT.Providers
             }
 
             context.Response.End();
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/WebServiceProxyProvider.cs
+++ b/src/WWT.Providers/Providers/WebServiceProxyProvider.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class WebServiceProxyProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string returnString = "Erorr: No URL Specified";
             string url = "";
@@ -36,6 +38,8 @@ namespace WWT.Providers
                     context.Response.Write(returnString);
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/XML2WTTProvider.cs
+++ b/src/WWT.Providers/Providers/XML2WTTProvider.cs
@@ -1,4 +1,6 @@
 using System.Configuration;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -10,9 +12,8 @@ namespace WWT.Providers
         {
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
-            //string etag = context.Request.Headers["If-None-Match"];
             string tourcache = ConfigurationManager.AppSettings["WWTTOURCACHE"];
 
             context.Response.ClearHeaders();
@@ -21,7 +22,7 @@ namespace WWT.Providers
 
             context.Response.WriteFile(MakeTourFromXML(context, context.Request.InputStream, tourcache + "\\temp\\"));
 
-            //context.Response.OutputStream
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/demmarsProvider.cs
+++ b/src/WWT.Providers/Providers/demmarsProvider.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -12,7 +14,7 @@ namespace WWT.Providers
             _plateTiles = plateTiles;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -39,6 +41,8 @@ namespace WWT.Providers
                     }
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/demmars_newProvider.cs
+++ b/src/WWT.Providers/Providers/demmars_newProvider.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -12,7 +14,7 @@ namespace WWT.Providers
             _plateTile = plateTile;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -41,6 +43,8 @@ namespace WWT.Providers
                     }
                 }
             }
+
+            return Task.CompletedTask;
         }
 
         private uint ComputeHash(int level, int x, int y)

--- a/src/WWT.Providers/Providers/g360Provider.cs
+++ b/src/WWT.Providers/Providers/g360Provider.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -14,7 +16,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -49,6 +51,8 @@ namespace WWT.Providers
                     }
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/hAlphaToastProvider.cs
+++ b/src/WWT.Providers/Providers/hAlphaToastProvider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -15,7 +17,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -32,9 +34,11 @@ namespace WWT.Providers
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/isstle2Provider.cs
+++ b/src/WWT.Providers/Providers/isstle2Provider.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class isstle2Provider : isstle
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string url = "";
 
@@ -85,6 +87,8 @@ namespace WWT.Providers
                     context.Response.Write(reply);
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/isstleProvider.cs
+++ b/src/WWT.Providers/Providers/isstleProvider.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class isstleProvider : isstle
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string url = "";
 
@@ -77,6 +79,8 @@ namespace WWT.Providers
                     context.Response.Write(reply);
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/loginProvider.cs
+++ b/src/WWT.Providers/Providers/loginProvider.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Configuration;
 using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class loginProvider : LoginUser
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string wwt2dir = ConfigurationManager.AppSettings["WWT2DIR"];
             context.Response.AddHeader("Cache-Control", "no-cache");
@@ -51,6 +53,8 @@ namespace WWT.Providers
             catch
             {
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/mandel1Provider.cs
+++ b/src/WWT.Providers/Providers/mandel1Provider.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class mandel1Provider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -61,6 +63,8 @@ namespace WWT.Providers
             b.Save(context.Response.OutputStream, ImageFormat.Jpeg);
             b.Dispose();
             context.Response.End();
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/marsProvider.cs
+++ b/src/WWT.Providers/Providers/marsProvider.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -14,7 +16,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -31,9 +33,10 @@ namespace WWT.Providers
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/marsdemProvider.cs
+++ b/src/WWT.Providers/Providers/marsdemProvider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
@@ -12,7 +14,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -43,6 +45,8 @@ namespace WWT.Providers
             }
 
             context.Response.End();
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/moonOctProvider.cs
+++ b/src/WWT.Providers/Providers/moonOctProvider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -15,7 +17,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -32,9 +34,10 @@ namespace WWT.Providers
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/moondemProvider.cs
+++ b/src/WWT.Providers/Providers/moondemProvider.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Configuration;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class moondemProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -20,7 +22,6 @@ namespace WWT.Providers
 
             if (File.Exists(filename))
             {
-
                 byte[] data = new byte[demSize];
                 FileStream fs = File.OpenRead(filename);
                 fs.Seek((long)(demSize * tileX), SeekOrigin.Begin);
@@ -29,21 +30,18 @@ namespace WWT.Providers
                 fs.Close();
                 context.Response.OutputStream.Write(data, 0, demSize);
                 context.Response.OutputStream.Flush();
-
-
             }
             else
             {
-
                 byte[] data = new byte[demSize];
 
                 context.Response.OutputStream.Write(data, 0, demSize);
                 context.Response.OutputStream.Flush();
-
-
             }
 
             context.Response.End();
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/moontoastProvider.cs
+++ b/src/WWT.Providers/Providers/moontoastProvider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -15,7 +17,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string wwtTilesDir = Path.Combine(_options.WwtTilesDir, "LROWAC");
 
@@ -29,7 +31,7 @@ namespace WWT.Providers
             {
                 context.Response.Write("No image");
                 context.Response.Close();
-                return;
+                return Task.CompletedTask;
             }
 
             if (level < 7)
@@ -41,7 +43,7 @@ namespace WWT.Providers
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
             else
@@ -60,7 +62,7 @@ namespace WWT.Providers
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/WWT.Providers/Providers/moontoastdemProvider.cs
+++ b/src/WWT.Providers/Providers/moontoastdemProvider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -15,7 +17,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string wwtDemDir = Path.Combine(_options.WWTDEMDir, "toast", "lola");
 
@@ -29,7 +31,7 @@ namespace WWT.Providers
             {
                 context.Response.Write("No image");
                 context.Response.Close();
-                return;
+                return Task.CompletedTask;
             }
 
             if (level < 7)
@@ -40,7 +42,7 @@ namespace WWT.Providers
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
             else
@@ -60,7 +62,7 @@ namespace WWT.Providers
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/WWT.Providers/Providers/testProvider.cs
+++ b/src/WWT.Providers/Providers/testProvider.cs
@@ -1,16 +1,19 @@
 using System;
 using System.Configuration;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Web;
 
 namespace WWT.Providers
 {
     public class testProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             String baseName = ConfigurationManager.AppSettings["WWTToursTourFileUNC"].ToLower();
             context.Response.Write(baseName);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/testfailoverProvider.cs
+++ b/src/WWT.Providers/Providers/testfailoverProvider.cs
@@ -1,13 +1,16 @@
 using System.Configuration;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
 {
     public class testfailoverProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             context.Response.Write(ConfigurationManager.AppSettings["DSSTOASTPNG"]);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/thumbnailProvider.cs
+++ b/src/WWT.Providers/Providers/thumbnailProvider.cs
@@ -1,3 +1,6 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace WWT.Providers
 {
     public class ThumbnailProvider : RequestProvider
@@ -9,7 +12,7 @@ namespace WWT.Providers
             _thumbnails = thumbnails;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token) 
         {
             string name = context.Request.Params["name"];
             string type = context.Request.Params["class"];
@@ -20,6 +23,8 @@ namespace WWT.Providers
                 context.Response.Flush();
                 context.Response.End();
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/tiles2Provider.cs
+++ b/src/WWT.Providers/Providers/tiles2Provider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -15,7 +17,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -40,7 +42,6 @@ namespace WWT.Providers
                         context.Response.ContentType = "text/plain";
                         context.Response.Write("No image");
                         context.Response.End();
-                        return;
                     }
                     else
                     {
@@ -50,6 +51,8 @@ namespace WWT.Providers
                     }
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/tilesProvider.cs
+++ b/src/WWT.Providers/Providers/tilesProvider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -14,7 +16,8 @@ namespace WWT.Providers
             _plateTiles = plateTiles;
             _options = options;
         }
-        public override void Run(IWwtContext context)
+
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -50,6 +53,8 @@ namespace WWT.Providers
                     }
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/tilethumbProvider.cs
+++ b/src/WWT.Providers/Providers/tilethumbProvider.cs
@@ -1,4 +1,6 @@
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
@@ -11,7 +13,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string name = context.Request.Params["name"];
             string path = Path.Combine(_options.DSSTileCache, "imagesTiler", "thumbnails");
@@ -22,6 +24,8 @@ namespace WWT.Providers
                 context.Response.WriteFile(filename);
                 context.Response.End();
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/veblendProvider.cs
+++ b/src/WWT.Providers/Providers/veblendProvider.cs
@@ -4,13 +4,15 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
 {
     public class veblendProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = "";
 
@@ -22,7 +24,7 @@ namespace WWT.Providers
             {
                 context.Response.Write("No image");
                 context.Response.End();
-                return;
+                return Task.CompletedTask;
             }
 
             string veKey = query;
@@ -46,7 +48,7 @@ namespace WWT.Providers
             {
                 context.Response.Write("No image");
                 context.Response.Close();
-                return;
+                return Task.CompletedTask;
             }
 
 
@@ -108,6 +110,8 @@ namespace WWT.Providers
             {
             }
             context.Response.End();
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/versionProvider.cs
+++ b/src/WWT.Providers/Providers/versionProvider.cs
@@ -1,13 +1,16 @@
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class VersionProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             context.Response.AddHeader("Cache-Control", "no-cache");
             context.Response.WriteFile(context.MapPath(Path.Combine("..", "wwt2", "version.txt")));
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/versionsProvider.cs
+++ b/src/WWT.Providers/Providers/versionsProvider.cs
@@ -1,10 +1,12 @@
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class VersionsProvider : RequestProvider
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             context.Response.AddHeader("Cache-Control", "no-cache");
 
@@ -16,6 +18,8 @@ namespace WWT.Providers
             context.Response.WriteFile(Path.Combine(wwt2dir, "dataversion.txt"));
             context.Response.Write("\nMessage:");
             context.Response.WriteFile(Path.Combine(wwt2dir, "message.txt"));
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/vlssToastProvider.cs
+++ b/src/WWT.Providers/Providers/vlssToastProvider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -15,7 +17,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -34,6 +36,8 @@ namespace WWT.Providers
                     context.Response.End();
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/webloginProvider.cs
+++ b/src/WWT.Providers/Providers/webloginProvider.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Configuration;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     public class webloginProvider : LoginWebUser
     {
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             context.Response.AddHeader("Cache-Control", "no-cache");
             context.Response.Expires = -1;
@@ -50,6 +52,8 @@ namespace WWT.Providers
             {
                 context.Response.Write("Key:Failed");
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/Providers/wmapProvider.cs
+++ b/src/WWT.Providers/Providers/wmapProvider.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -15,7 +17,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override void Run(IWwtContext context)
+        public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
             string[] values = query.Split(',');
@@ -32,9 +34,10 @@ namespace WWT.Providers
                     s.CopyTo(context.Response.OutputStream);
                     context.Response.Flush();
                     context.Response.End();
-                    return;
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/WWT.Providers/RequestProvider.cs
+++ b/src/WWT.Providers/RequestProvider.cs
@@ -1,7 +1,10 @@
-﻿namespace WWT.Providers
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace WWT.Providers
 {
     public abstract class RequestProvider
     {
-        public abstract void Run(IWwtContext context);
+        public abstract Task RunAsync(IWwtContext context, CancellationToken token);
     }
 }

--- a/src/WWTMVC5/WwtWebHttpHandler.cs
+++ b/src/WWTMVC5/WwtWebHttpHandler.cs
@@ -2,16 +2,17 @@
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Web;
 using WWT.Providers;
 
 namespace WWTMVC5
 {
-    public class WwtWebHttpHandler : IHttpHandler
+    public class WwtWebHttpHandler : HttpTaskAsyncHandler
     {
         private static EndpointManager _endpoints;
 
-        public void ProcessRequest(HttpContext context)
+        public override async Task ProcessRequestAsync(HttpContext context)
         {
             using (var scope = _endpoints.GetRequestScope(context.Request.Path))
             {
@@ -28,12 +29,12 @@ namespace WWTMVC5
 
                     scope.Resolve<ILogger<WwtWebHttpHandler>>().LogInformation("Dispatch {Path} to {Provider}", context.Request.Path, scope.Provider.GetType());
 
-                    scope.Provider.Run(new SystemWebWwtContext(context));
+                    await scope.Provider.RunAsync(new SystemWebWwtContext(context), context.Response.ClientDisconnectedToken);
                 }
             }
         }
 
-        public bool IsReusable => true;
+        public override bool IsReusable => true;
 
         public static void Initialize(IServiceProvider provider)
         {

--- a/tests/WWT.Providers.Tests/HttpAutoSubstituteExtensions.cs
+++ b/tests/WWT.Providers.Tests/HttpAutoSubstituteExtensions.cs
@@ -4,6 +4,7 @@ using NSubstitute;
 using NSubstitute.Core;
 using System;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace WWT.Providers.Tests
 {
@@ -12,10 +13,10 @@ namespace WWT.Providers.Tests
         public static byte[] GetOutputData(this AutoSubstitute container)
             => container.Resolve<IResponse>().OutputStream.ToArray();
 
-        public static void RunProviderTest<T>(this AutoSubstitute container)
+        public static Task RunProviderTestAsync<T>(this AutoSubstitute container)
             where T : RequestProvider
         {
-            container.Resolve<T>().Run(container.Resolve<IWwtContext>());
+            return container.Resolve<T>().RunAsync(container.Resolve<IWwtContext>(), default);
         }
 
         public static AutoSubstituteBuilder RegisterAfterBuild<T>(this AutoSubstituteBuilder builder, Action<T, IComponentContext> action)

--- a/tests/WWT.Providers.Tests/ProviderTests.cs
+++ b/tests/WWT.Providers.Tests/ProviderTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using WWTWebservices;
 using Xunit;
 
@@ -49,7 +50,7 @@ namespace WWT.Providers.Tests
             => new object[] { level, x, y };
 
         [Fact]
-        public void ExpectedTests()
+        public async Task ExpectedTests()
         {
             for (int level = 0; level < MaxLevel; level++)
             {
@@ -67,7 +68,7 @@ namespace WWT.Providers.Tests
                 GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>(), level, x, y).Returns(new MemoryStream(data));
 
                 // Act
-                container.RunProviderTest<T>();
+                await container.RunProviderTestAsync<T>();
 
                 // Assert
                 GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>().Received(1), level, x, y);
@@ -76,7 +77,7 @@ namespace WWT.Providers.Tests
         }
 
         [Fact]
-        public void ErrorInStream()
+        public async Task ErrorInStream()
         {
             var maxLevel = MaxLevel < 0 ? 10 : MaxLevel;
 
@@ -98,12 +99,12 @@ namespace WWT.Providers.Tests
                 if (StreamExceptionResponseHandler is null)
                 {
                     // Act
-                    Assert.Throws<InvalidOperationException>(() => container.RunProviderTest<T>());
+                    await Assert.ThrowsAsync<InvalidOperationException>(() => container.RunProviderTestAsync<T>());
                 }
                 else
                 {
                     // Act
-                    container.RunProviderTest<T>();
+                    await container.RunProviderTestAsync<T>();
 
                     // Assert
                     GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>().Received(1), level, x, y);
@@ -113,7 +114,7 @@ namespace WWT.Providers.Tests
         }
 
         [Fact]
-        public void EmptyResult()
+        public async Task EmptyResult()
         {
             // Arrange
             var level = Fixture.Create<int>() % MaxLevel;
@@ -130,7 +131,7 @@ namespace WWT.Providers.Tests
             GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>(), level, x, y).Returns(empty);
 
             // Act
-            container.RunProviderTest<T>();
+            await container.RunProviderTestAsync<T>();
 
             // Assert
             GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>().Received(1), level, x, y);
@@ -138,7 +139,7 @@ namespace WWT.Providers.Tests
         }
 
         [Fact]
-        public void NullResult()
+        public async Task NullResult()
         {
             // Arrange
             var level = Fixture.Create<int>() % MaxLevel;
@@ -155,12 +156,12 @@ namespace WWT.Providers.Tests
 
             if (NullStreamResponseHandler is null)
             {
-                Assert.Throws<NullReferenceException>(() => container.RunProviderTest<T>());
+                await Assert.ThrowsAsync<NullReferenceException>(() => container.RunProviderTestAsync<T>());
             }
             else
             {
                 // Act
-                container.RunProviderTest<T>();
+                await container.RunProviderTestAsync<T>();
 
                 // Assert
                 GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>().Received(1), level, x, y);
@@ -169,7 +170,7 @@ namespace WWT.Providers.Tests
         }
 
         [Fact]
-        public void AboveMaxLevel()
+        public async Task AboveMaxLevel()
         {
             if (MaxLevel < 0)
             {
@@ -189,7 +190,7 @@ namespace WWT.Providers.Tests
                     .Build();
 
                 // Act
-                container.RunProviderTest<T>();
+                await container.RunProviderTestAsync<T>();
 
                 // Assert
                 ExpectedResponseAboveMaxLevel(container.Resolve<IResponse>());

--- a/tests/WWT.Providers.Tests/WWT.Providers.Tests.csproj
+++ b/tests/WWT.Providers.Tests/WWT.Providers.Tests.csproj
@@ -8,8 +8,4 @@
     <ProjectReference Include="..\..\src\WWT.Providers\WWT.Providers.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Web" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
The system currently is completely synchronous. However, this ends up with thread blocking while waiting for calls to Azure and other network resources. This change enables asynchronous connections by updating the infrastructure to use Tasks. Subsequent changes will update the access to Azure via async methods as well including for tours, plate files, thumbnails, and future ones.