### PR TITLE
Remove System.Web dependency from providers

### DIFF
--- a/src/WWT.Providers/ICache.cs
+++ b/src/WWT.Providers/ICache.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Web.Caching;
 
 namespace WWT.Providers
 {

--- a/src/WWT.Providers/Providers/Goto2Provider.cs
+++ b/src/WWT.Providers/Providers/Goto2Provider.cs
@@ -1,7 +1,7 @@
 using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace WWT.Providers
 {
@@ -11,7 +11,7 @@ namespace WWT.Providers
         {
             if (context.Request.ContainsCookie("alphakey") && context.Request.Params["wtml"] == null)
             {
-                context.Response.Redirect("http://www.worldwidetelescope.org/webclient/default.aspx?wtml=" + HttpUtility.UrlEncode(context.Request.Url.ToString() + "&wtml=true"));
+                context.Response.Redirect("http://www.worldwidetelescope.org/webclient/default.aspx?wtml=" + WebUtility.UrlEncode(context.Request.Url.ToString() + "&wtml=true"));
                 return Task.CompletedTask;
             }
 

--- a/src/WWT.Providers/Providers/GotoProvider.cs
+++ b/src/WWT.Providers/Providers/GotoProvider.cs
@@ -1,7 +1,7 @@
 using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace WWT.Providers
 {
@@ -11,7 +11,7 @@ namespace WWT.Providers
         {
             if (!context.Request.ContainsCookie("fullclient") && context.Request.Params["wtml"] == null)
             {
-                context.Response.Redirect("http://www.worldwidetelescope.org/webclient/default.aspx?wtml=" + HttpUtility.UrlEncode(context.Request.Url.ToString() + "&wtml=true"));
+                context.Response.Redirect("http://www.worldwidetelescope.org/webclient/default.aspx?wtml=" + WebUtility.UrlEncode(context.Request.Url.ToString() + "&wtml=true"));
                 return Task.CompletedTask;
             }
 

--- a/src/WWT.Providers/Providers/ShowImage2Provider.cs
+++ b/src/WWT.Providers/Providers/ShowImage2Provider.cs
@@ -1,7 +1,7 @@
 using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace WWT.Providers
 {
@@ -11,7 +11,7 @@ namespace WWT.Providers
         {
             if (context.Request.ContainsCookie("alphakey"))
             {
-                context.Response.Redirect("http://www.worldwidetelescope.org/webclient/default.aspx?Wtml=" + HttpUtility.UrlEncode(context.Request.Url.ToString() + "&wtml=true"));
+                context.Response.Redirect("http://www.worldwidetelescope.org/webclient/default.aspx?Wtml=" + WebUtility.UrlEncode(context.Request.Url.ToString() + "&wtml=true"));
                 return Task.CompletedTask;
             }
 

--- a/src/WWT.Providers/Providers/ShowImageProvider.cs
+++ b/src/WWT.Providers/Providers/ShowImageProvider.cs
@@ -1,7 +1,7 @@
 using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace WWT.Providers
 {
@@ -11,7 +11,7 @@ namespace WWT.Providers
         {
             if (!context.Request.ContainsCookie("fullclient") && context.Request.Params["wtml"] == null)
             {
-                context.Response.Redirect("http://www.worldwidetelescope.org/webclient/default.aspx?wtml=" + HttpUtility.UrlEncode(context.Request.Url.ToString().Replace(",", "-") + "&wtml=true"));
+                context.Response.Redirect("http://www.worldwidetelescope.org/webclient/default.aspx?wtml=" + WebUtility.UrlEncode(context.Request.Url.ToString().Replace(",", "-") + "&wtml=true"));
                 return Task.CompletedTask;
             }
 

--- a/src/WWT.Providers/Providers/testProvider.cs
+++ b/src/WWT.Providers/Providers/testProvider.cs
@@ -3,8 +3,6 @@ using System.Configuration;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
-
 namespace WWT.Providers
 {
     public class testProvider : RequestProvider

--- a/src/WWT.Providers/WWT.Providers.csproj
+++ b/src/WWT.Providers/WWT.Providers.csproj
@@ -19,7 +19,6 @@
 
   <ItemGroup>
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Web" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This replaces `System.Web.HttpUtility` with `System.Net.WebUtility` which has identical functionality but is cross-plat. With this change we now have no dependency in the WWT.Providers project on System.Web! This is not required at this time, but will make .NET Core much easier to get to.