### PR TITLE
Use FilePathOptions to retrieve app settings if possible

### DIFF
--- a/src/WWT.Providers/FilePathOptions.cs
+++ b/src/WWT.Providers/FilePathOptions.cs
@@ -4,6 +4,8 @@ namespace WWT.Providers
 {
     public class FilePathOptions
     {
+        public string DataDir { get; set; }
+
         public string DssTerapixelDir { get; set; }
 
         public string DSSTileCache { get; set; }
@@ -13,6 +15,8 @@ namespace WWT.Providers
         public string WWTDEMDir { get; set; }
 
         public string WwtTilesDir { get; set; }
+
+        public string WwtTourCache { get; set; }
 
         public string WwtToursTourFileUNC { get; set; }
 

--- a/src/WWT.Providers/IWwtContext.cs
+++ b/src/WWT.Providers/IWwtContext.cs
@@ -10,6 +10,6 @@
 
         string MachineName { get; }
 
-        string MapPath(string path);
+        string MapPath(params string[] path);
     }
 }

--- a/src/WWT.Providers/Providers/Catalog2Provider.cs
+++ b/src/WWT.Providers/Providers/Catalog2Provider.cs
@@ -1,5 +1,4 @@
-﻿using System.Configuration;
-using System.IO;
+﻿using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,11 +6,18 @@ namespace WWT.Providers
 {
     public class Catalog2Provider : RequestProvider
     {
+        private readonly FilePathOptions _options;
+
+        public Catalog2Provider(FilePathOptions options)
+        {
+            _options = options;
+        }
+
         public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string etag = context.Request.Headers["If-None-Match"];
             string filename = "";
-            string webDir = Path.Combine(ConfigurationManager.AppSettings["DataDir"], "data");
+            string webDir = Path.Combine(_options.DataDir, "data");
 
             if (context.Request.Params["Q"] != null)
             {

--- a/src/WWT.Providers/Providers/CatalogProvider.cs
+++ b/src/WWT.Providers/Providers/CatalogProvider.cs
@@ -1,5 +1,4 @@
-﻿using System.Configuration;
-using System.IO;
+﻿using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,11 +6,18 @@ namespace WWT.Providers
 {
     public class CatalogProvider : RequestProvider
     {
+        private readonly FilePathOptions _options;
+
+        public CatalogProvider(FilePathOptions options)
+        {
+            _options = options;
+        }
+
         public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string etag = context.Request.Headers["If-None-Match"];
             string filename = "";
-            string webDir = Path.Combine(ConfigurationManager.AppSettings["DataDir"], "data");
+            string webDir = Path.Combine(_options.DataDir, "data");
 
             if (context.Request.Params["Q"] != null)
             {

--- a/src/WWT.Providers/Providers/EarthBlendProvider.cs
+++ b/src/WWT.Providers/Providers/EarthBlendProvider.cs
@@ -121,7 +121,7 @@ namespace WWT.Providers
                         Graphics g = Graphics.FromImage(bmp);
                         g.InterpolationMode = InterpolationMode.HighQualityBicubic;
 
-                        string tempName = WWTUtil.DownloadVeTile(level, tileX, tileY, false);
+                        string tempName = WWTUtil.DownloadVeTile(level, tileX, tileY, _options.DSSTileCache, false);
                         FileInfo fi = new FileInfo(tempName);
                         if (fi.Length != 0 && fi.Length != 1033)
                         {

--- a/src/WWT.Providers/Providers/GetTileProvider.cs
+++ b/src/WWT.Providers/Providers/GetTileProvider.cs
@@ -1,14 +1,19 @@
 using System;
-using System.Configuration;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using WWTWebservices;
 
 namespace WWT.Providers
 {
     public class GetTileProvider : RequestProvider
     {
+        private readonly FilePathOptions _options;
+
+        public GetTileProvider(FilePathOptions options)
+        {
+            _options = options;
+        }
+
         public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
@@ -19,7 +24,7 @@ namespace WWT.Providers
             string dataset = values[3];
             string id = dataset;
 
-            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
+            string DSSTileCache = _options.DSSTileCache;
 
             string filename = String.Format(DSSTileCache + "\\imagesTiler\\{3}\\{0}\\{2}\\{2}_{1}.png", level, tileX, tileY, id);
 

--- a/src/WWT.Providers/Providers/GetTourList.aspx.cs
+++ b/src/WWT.Providers/Providers/GetTourList.aspx.cs
@@ -69,7 +69,7 @@ namespace WWT.Providers
 
         private int GetSQLTourArrayList(List<Tour> sqlTours, string query)
         {
-            StoredProc sp = new StoredProc(query);
+            StoredProc sp = new StoredProc(query, _options.WwtToursDBConnectionString);
             DataTable dt = new DataTable();
             int nRet = sp.RunQuery(dt);
             sp.Dispose();
@@ -125,7 +125,7 @@ namespace WWT.Providers
                 xmlWriter.WriteEndElement();
             }
 
-            StoredProc sp1 = new StoredProc(SqlCommandString + parcatId.ToString());
+            StoredProc sp1 = new StoredProc(SqlCommandString + parcatId.ToString(), _options.WwtToursDBConnectionString);
             DataTable dt = new DataTable();
             int nRet1 = sp1.RunQuery(dt);
             sp1.Dispose();
@@ -184,7 +184,7 @@ namespace WWT.Providers
                         }
                     }
 
-                    StoredProc sp1 = new StoredProc(HierarchySqlCommand);
+                    StoredProc sp1 = new StoredProc(HierarchySqlCommand, _options.WwtToursDBConnectionString);
                     DataTable dt = new DataTable();
                     int nRet1 = sp1.RunQuery(dt);
                     sp1.Dispose();

--- a/src/WWT.Providers/Providers/PostRatingFeedbackProvider.cs
+++ b/src/WWT.Providers/Providers/PostRatingFeedbackProvider.cs
@@ -9,6 +9,13 @@ namespace WWT.Providers
 {
     public class PostRatingFeedbackProvider : RequestProvider
     {
+        private readonly FilePathOptions _options;
+
+        public PostRatingFeedbackProvider(FilePathOptions options)
+        {
+            _options = options;
+        }
+
         public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             context.Response.ClearHeaders();
@@ -33,16 +40,16 @@ namespace WWT.Providers
             return Task.CompletedTask;
         }
 
-        private static SqlConnection GetConnectionWWTTours()
+        private SqlConnection GetConnectionWWTTours()
         {
             string connStr = null;
-            connStr = ConfigurationManager.AppSettings["WWTToursDBConnectionString"];
+            connStr = _options.WwtToursDBConnectionString;
             SqlConnection myConnection = null;
             myConnection = new SqlConnection(connStr);
             return myConnection;
         }
 
-        private static void PostFeedback(string tour, string User, int rating)
+        private void PostFeedback(string tour, string User, int rating)
         {
             string strErrorMsg;
             SqlConnection myConnection5 = GetConnectionWWTTours();

--- a/src/WWT.Providers/Providers/TileImage.aspx.cs
+++ b/src/WWT.Providers/Providers/TileImage.aspx.cs
@@ -10,9 +10,16 @@ namespace WWT.Providers
 {
     public abstract partial class TileImage : RequestProvider
     {
+        protected readonly FilePathOptions _options;
+
+        public TileImage(FilePathOptions options)
+        {
+            _options = options;
+        }
+
         public void TileBitmap(Bitmap bmp, string ID)
         {
-            string baseDirectory = ConfigurationManager.AppSettings["DSSTileCache"] + "\\imagesTiler\\";
+            string baseDirectory = _options.DSSTileCache + "\\imagesTiler\\";
             int width = bmp.Width;
             int height = bmp.Height;
             double aspect = (double)width / (double)height;
@@ -104,9 +111,9 @@ namespace WWT.Providers
             }
         }
 
-        public static void MakeThumbnail(Bitmap imgOrig, string hashID)
+        public void MakeThumbnail(Bitmap imgOrig, string hashID)
         {
-            string path = ConfigurationManager.AppSettings["DSSTileCache"] + "\\imagesTiler\\thumbnails\\";
+            string path = _options.DSSTileCache + "\\imagesTiler\\thumbnails\\";
 
             string filename = path + hashID + ".jpg";
 

--- a/src/WWT.Providers/Providers/TileImageProvider.cs
+++ b/src/WWT.Providers/Providers/TileImageProvider.cs
@@ -13,7 +13,8 @@ namespace WWT.Providers
     {
         private readonly IFileNameHasher _hasher;
 
-        public TileImageProvider(IFileNameHasher hasher)
+        public TileImageProvider(IFileNameHasher hasher, FilePathOptions options)
+            : base(options)
         {
             _hasher = hasher;
         }
@@ -66,7 +67,7 @@ namespace WWT.Providers
                 int hashID = _hasher.HashName(url);
 
                 //hashID = 12345;
-                string path = ConfigurationManager.AppSettings["DSSTileCache"] + "\\imagesTiler\\dowloadImages\\";
+                string path = _options.DSSTileCache + "\\imagesTiler\\dowloadImages\\";
 
                 string filename = path + hashID + ".png";
 

--- a/src/WWT.Providers/Providers/WMSEarthTodayProvider.cs
+++ b/src/WWT.Providers/Providers/WMSEarthTodayProvider.cs
@@ -12,10 +12,12 @@ namespace WWT.Providers
     public class WMSEarthTodayProvider : RequestProvider
     {
         private readonly IFileNameHasher _hasher;
+        private readonly FilePathOptions _options;
 
-        public WMSEarthTodayProvider(IFileNameHasher hasher)
+        public WMSEarthTodayProvider(IFileNameHasher hasher, FilePathOptions options)
         {
             _hasher = hasher;
+            _options = options;
         }
 
         public override Task RunAsync(IWwtContext context, CancellationToken token)
@@ -29,7 +31,7 @@ namespace WWT.Providers
             string wmsUrl = values[3];
             string dirPart = _hasher.HashName(wmsUrl).ToString();
 
-            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
+            string DSSTileCache = _options.DSSTileCache;
 
             var filename = String.Format(DSSTileCache + "\\WMS\\{3}\\{0}\\{2}\\{2}_{1}.png", level, tileX, tileY, dirPart);
             var path = String.Format(DSSTileCache + "\\WMS\\{3}\\{0}\\{2}", level, tileX, tileY, dirPart);

--- a/src/WWT.Providers/Providers/WMSToastProvider.cs
+++ b/src/WWT.Providers/Providers/WMSToastProvider.cs
@@ -12,10 +12,12 @@ namespace WWT.Providers
     public class WMSToastProvider : RequestProvider
     {
         private readonly IFileNameHasher _hasher;
+        private readonly FilePathOptions _options;
 
-        public WMSToastProvider(IFileNameHasher hasher)
+        public WMSToastProvider(IFileNameHasher hasher, FilePathOptions options)
         {
             _hasher = hasher;
+            _options = options;
         }
 
         public override Task RunAsync(IWwtContext context, CancellationToken token)
@@ -32,7 +34,7 @@ namespace WWT.Providers
             string filename;
             string path;
 
-            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
+            string DSSTileCache = _options.DSSTileCache;
             filename = String.Format(DSSTileCache + "\\WMS\\{3}\\{0}\\{2}\\{2}_{1}.png", level, tileX, tileY, dirPart);
             path = String.Format(DSSTileCache + "\\WMS\\{3}\\{0}\\{2}", level, tileX, tileY, dirPart);
 

--- a/src/WWT.Providers/Providers/XML2WTTProvider.cs
+++ b/src/WWT.Providers/Providers/XML2WTTProvider.cs
@@ -7,14 +7,17 @@ namespace WWT.Providers
 {
     public class XML2WTTProvider : WWTWeb_XML2WTT
     {
-        public XML2WTTProvider(IFileNameHasher hasher)
+        private readonly FilePathOptions _options;
+
+        public XML2WTTProvider(IFileNameHasher hasher, FilePathOptions options)
             : base(hasher)
         {
+            _options = options;
         }
 
         public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
-            string tourcache = ConfigurationManager.AppSettings["WWTTOURCACHE"];
+            string tourcache = _options.WwtTourCache;
 
             context.Response.ClearHeaders();
             context.Response.Clear();

--- a/src/WWT.Providers/Providers/loginProvider.cs
+++ b/src/WWT.Providers/Providers/loginProvider.cs
@@ -10,7 +10,6 @@ namespace WWT.Providers
     {
         public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
-            string wwt2dir = ConfigurationManager.AppSettings["WWT2DIR"];
             context.Response.AddHeader("Cache-Control", "no-cache");
             context.Response.Expires = -1;
             context.Response.CacheControl = "no-cache";
@@ -18,23 +17,23 @@ namespace WWT.Providers
 
             if (context.Request.Params["Equinox"] != null)
             {
-                context.Response.WriteFile(wwt2dir + @"\EqClientVersion.txt");
+                context.Response.WriteFile(context.MapPath("wwt2", "EqClientVersion.txt"));
                 context.Response.Write("\n");
             }
             else
             {
                 context.Response.Write("ClientVersion:");
-                context.Response.WriteFile(wwt2dir + @"\ClientVersion.txt");
+                context.Response.WriteFile(context.MapPath("wwt2", "ClientVersion.txt"));
                 context.Response.Write("\n");
-                context.Response.WriteFile(wwt2dir + @"\dataversion.txt");
+                context.Response.WriteFile(context.MapPath("wwt2", "dataversion.txt"));
                 context.Response.Write("\nMessage:");
-                context.Response.WriteFile(wwt2dir + @"\message.txt");
+                context.Response.WriteFile(context.MapPath("wwt2", "message.txt"));
                 context.Response.Write("\nWarnVersion:");
-                context.Response.WriteFile(wwt2dir + @"\warnver.txt");
+                context.Response.WriteFile(context.MapPath("wwt2", "warnver.txt"));
                 context.Response.Write("\nMinVersion:");
-                context.Response.WriteFile(wwt2dir + @"\minver.txt");
+                context.Response.WriteFile(context.MapPath("wwt2", "minver.txt"));
                 context.Response.Write("\nUpdateUrl:");
-                context.Response.WriteFile(wwt2dir + @"\updateurl.txt");
+                context.Response.WriteFile(context.MapPath("wwt2", "updateurl.txt"));
             }
             context.Response.Flush();
 

--- a/src/WWT.Providers/Providers/moondemProvider.cs
+++ b/src/WWT.Providers/Providers/moondemProvider.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Configuration;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,6 +7,13 @@ namespace WWT.Providers
 {
     public class moondemProvider : RequestProvider
     {
+        private readonly FilePathOptions _options;
+
+        public moondemProvider(FilePathOptions options)
+        {
+            _options = options;
+        }
+
         public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = context.Request.Params["Q"];
@@ -17,7 +23,7 @@ namespace WWT.Providers
             int tileY = Convert.ToInt32(values[2]);
             string type = values[3];
             int demSize = 513 * 2;
-            string wwtDemDir = ConfigurationManager.AppSettings["WWTDEMDir"];
+            string wwtDemDir = _options.WWTDEMDir;
             string filename = String.Format(wwtDemDir + @"\toast\moon\Chunks\{0}\{1}.chunk", level, tileY);
 
             if (File.Exists(filename))

--- a/src/WWT.Providers/Providers/testProvider.cs
+++ b/src/WWT.Providers/Providers/testProvider.cs
@@ -1,15 +1,21 @@
 using System;
-using System.Configuration;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+
 namespace WWT.Providers
 {
     public class testProvider : RequestProvider
     {
+        private readonly FilePathOptions _options;
+
+        public testProvider(FilePathOptions options)
+        {
+            _options = options;
+        }
+
         public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
-            String baseName = ConfigurationManager.AppSettings["WWTToursTourFileUNC"].ToLower();
+            String baseName = _options.WwtToursTourFileUNC.ToLower();
             context.Response.Write(baseName);
             return Task.CompletedTask;
         }

--- a/src/WWT.Providers/Providers/testfailoverProvider.cs
+++ b/src/WWT.Providers/Providers/testfailoverProvider.cs
@@ -1,15 +1,20 @@
-using System.Configuration;
 using System.Threading;
 using System.Threading.Tasks;
-using WWTWebservices;
 
 namespace WWT.Providers
 {
     public class testfailoverProvider : RequestProvider
     {
+        private readonly FilePathOptions _options;
+
+        public testfailoverProvider(FilePathOptions options)
+        {
+            _options = options;
+        }
+
         public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
-            context.Response.Write(ConfigurationManager.AppSettings["DSSTOASTPNG"]);
+            context.Response.Write(_options.DssToastPng);
             return Task.CompletedTask;
         }
     }

--- a/src/WWT.Providers/Providers/veblendProvider.cs
+++ b/src/WWT.Providers/Providers/veblendProvider.cs
@@ -12,6 +12,13 @@ namespace WWT.Providers
 {
     public class veblendProvider : RequestProvider
     {
+        private readonly FilePathOptions _options;
+
+        public veblendProvider(FilePathOptions options)
+        {
+            _options = options;
+        }
+
         public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             string query = "";
@@ -39,7 +46,7 @@ namespace WWT.Providers
             string filename;
             string path;
 
-            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
+            string DSSTileCache = _options.DSSTileCache;
             filename = String.Format(DSSTileCache + "\\VE\\level{0}\\{2}\\{1}_{2}.jpg", level, tileX, tileY);
             path = String.Format(DSSTileCache + "\\VE\\level{0}\\{2}", level, tileX, tileY);
 
@@ -61,7 +68,7 @@ namespace WWT.Providers
                         Directory.CreateDirectory(path);
                     }
 
-                    WWTUtil.DownloadVeTile(level, tileX, tileY, true);
+                    WWTUtil.DownloadVeTile(level, tileX, tileY, _options.DSSTileCache, true);
 
                     float[][] ptsArray ={
                                     new float[] {1, 0, 0, 0, 0},
@@ -74,14 +81,14 @@ namespace WWT.Providers
                     imgAttributes.SetColorMatrix(clrMatrix,
                         ColorMatrixFlag.Default,
                         ColorAdjustType.Bitmap);
-                    Bitmap bmp = new Bitmap(WWTUtil.DownloadVeTile(level, tileX, tileY, true));
+                    Bitmap bmp = new Bitmap(WWTUtil.DownloadVeTile(level, tileX, tileY, _options.DSSTileCache, true));
                     Graphics g = Graphics.FromImage(bmp);
                     g.InterpolationMode = InterpolationMode.HighQualityBicubic;
                     for (int y = 0; y < 2; y++)
                     {
                         for (int x = 0; x < 2; x++)
                         {
-                            string tempName = WWTUtil.DownloadVeTile(level + 1, tileX * 2 + x, tileY * 2 + y, false);
+                            string tempName = WWTUtil.DownloadVeTile(level + 1, tileX * 2 + x, tileY * 2 + y, _options.DSSTileCache, false);
                             FileInfo fi = new FileInfo(tempName);
                             if (fi.Length != 0 && fi.Length != 1033)
                             {
@@ -97,10 +104,8 @@ namespace WWT.Providers
                 }
                 else
                 {
-                    WWTUtil.DownloadVeTile(level, tileX, tileY, false);
+                    WWTUtil.DownloadVeTile(level, tileX, tileY, _options.DSSTileCache, false);
                 }
-
-
             }
             try
             {

--- a/src/WWTMVC5/Global.asax.cs
+++ b/src/WWTMVC5/Global.asax.cs
@@ -73,6 +73,7 @@ namespace WWTMVC5
 
             services.AddRequestProviders(options =>
             {
+                options.DataDir = ConfigurationManager.AppSettings["DataDir"];
                 options.DssTerapixelDir = ConfigurationManager.AppSettings["DssTerapixelDir"];
                 options.DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
                 options.DssToastPng = ConfigurationManager.AppSettings["DSSTOASTPNG"];
@@ -80,6 +81,7 @@ namespace WWTMVC5
                 options.WwtTilesDir = ConfigurationManager.AppSettings["WWTTilesDir"];
                 options.WwtGalexDir = ConfigurationManager.AppSettings["WWTGALEXDIR"];
                 options.WwtToursDBConnectionString = ConfigurationManager.AppSettings["WWTToursDBConnectionString"];
+                options.WwtTourCache = ConfigurationManager.AppSettings["WWTTOURCACHE"];
             });
 
             services

--- a/src/WWTMVC5/SystemWebWwtContext.cs
+++ b/src/WWTMVC5/SystemWebWwtContext.cs
@@ -17,7 +17,7 @@ namespace WWTMVC5
 
         public string MachineName => _context.Server.MachineName;
 
-        public string MapPath(string path) => _context.Server.MapPath(path);
+        public string MapPath(params string[] path) => _context.Server.MapPath(Path.Combine(path));
 
         public IRequest Request => this;
 

--- a/src/WWTWebservices/StoredProc.cs
+++ b/src/WWTWebservices/StoredProc.cs
@@ -9,9 +9,9 @@ namespace WWTWebservices
     public class StoredProc
     {
         private SqlCommand cmd;
-        public StoredProc(string strQuery)
+        public StoredProc(string strQuery, string connectionString)
         {
-            cmd = new SqlCommand(strQuery, new SqlConnection(ConfigurationManager.AppSettings["WWTToursDBConnectionString"]));
+            cmd = new SqlCommand(strQuery, new SqlConnection(connectionString));
             cmd.CommandTimeout = 60;
             cmd.Parameters.Add(
                 new SqlParameter("ReturnValue",
@@ -32,30 +32,6 @@ namespace WWTWebservices
         ~StoredProc()
         {
             this.Dispose();
-        }
-
-        public StoredProc(string spName, SqlParameter[] sqlArgs)
-        {
-            cmd = new SqlCommand(spName, new SqlConnection(ConfigurationManager.AppSettings["WWTToursDBConnectionString"]));
-            cmd.CommandType = CommandType.StoredProcedure;
-
-            foreach (SqlParameter sqlArg in sqlArgs)
-                cmd.Parameters.Add(sqlArg);
-
-            cmd.Parameters.Add(
-                new SqlParameter("ReturnValue",
-                SqlDbType.Int,
-                /* int size */ 4,
-                ParameterDirection.ReturnValue,
-                /* bool isNullable */ false,
-                /* byte precision */ 0,
-                /* byte scale */ 0,
-                /* string srcColumn */ string.Empty,
-                DataRowVersion.Default,
-                /* value */ null
-                )
-            );
-            cmd.Connection.Open();
         }
 
         public StoredProc(string spName, SqlConnection conn)

--- a/src/WWTWebservices/WWTUtil.cs
+++ b/src/WWTWebservices/WWTUtil.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.Configuration;
 using System.IO;
 using System.Text;
-using System.Web;
 
 namespace WWTWebservices
 {
-
-
     public class WWTUtil
     {
         public WWTUtil()
@@ -122,9 +118,8 @@ namespace WWTWebservices
             return level;
         }
 
-        public static string DownloadVeTile(int level, int tileX, int tileY, bool temp)
+        public static string DownloadVeTile(int level, int tileX, int tileY,string DSSTileCache, bool temp)
         {
-            string DSSTileCache = ConfigurationManager.AppSettings["DSSTileCache"];
             string filename = String.Format(DSSTileCache + "\\VE\\level{0}\\{2}\\{1}_{2}.jpg", level, tileX, tileY);
             string path = String.Format(DSSTileCache + "\\VE\\level{0}\\{2}", level, tileX, tileY);
 


### PR DESCRIPTION
This moves the majority of the app settings retrieval (at least the folder name access) to FilePathOptions so we can easily see where they are being used.