### PR TITLE
Handle case sensitivty

### DIFF
--- a/src/WWT.Azure/AzureWwtExtensions.cs
+++ b/src/WWT.Azure/AzureWwtExtensions.cs
@@ -3,6 +3,7 @@ using Azure.Identity;
 using Azure.Storage.Blobs;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using WWT.PlateFiles;
 using WWT.Tours;
 using WWTWebservices;
 
@@ -49,6 +50,7 @@ namespace WWT.Azure
             if (options.UseAzurePlateFiles)
             {
                 services.Services.AddSingleton<IPlateTilePyramid, SeekableAzurePlateTilePyramid>();
+                services.Services.AddSingleton<IKnownPlateFiles, AzureKnownPlateFile>();
             }
             else
             {

--- a/src/WWT.Azure/Imaging/AzureThumbnailAccessor.cs
+++ b/src/WWT.Azure/Imaging/AzureThumbnailAccessor.cs
@@ -15,7 +15,7 @@ namespace WWT.Azure
         }
 
         public Stream GetThumbnailStream(string name, string type)
-            => GetThumbnailStream(name) ?? GetThumbnailStream(type) ?? GetThumbnailStream(_options.Default);
+            => GetThumbnailStream(name.ToLowerInvariant()) ?? GetThumbnailStream(type.ToLowerInvariant()) ?? GetThumbnailStream(_options.Default);
 
         private Stream GetThumbnailStream(string fileName)
             => GetThumbnailStreamFromFile(fileName, "fromAssembly") ?? GetThumbnailStreamFromFile(fileName, "fromBackup");

--- a/src/WWT.Azure/PlateFiles/AzureKnownPlateFile.cs
+++ b/src/WWT.Azure/PlateFiles/AzureKnownPlateFile.cs
@@ -1,0 +1,53 @@
+﻿using Azure.Storage.Blobs;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using WWT.PlateFiles;
+
+namespace WWT.Azure
+{
+    public class AzureKnownPlateFile : IKnownPlateFiles
+    {
+        private readonly Dictionary<string, string> _map;
+
+        public AzureKnownPlateFile(AzurePlateTilePyramidOptions options, BlobServiceClient service, ILogger<AzureKnownPlateFile> logger)
+        {
+            _map = BuildMap(options, service, logger);
+        }
+
+        public bool TryNormalizePlateName(string input, out string platefile)
+            => _map.TryGetValue(input, out platefile);
+
+        private static Dictionary<string, string> BuildMap(AzurePlateTilePyramidOptions options, BlobServiceClient service, ILogger<AzureKnownPlateFile> logger)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            try
+            {
+                var blob = service.GetBlobContainerClient(options.Container).GetBlobClient(options.KnownPlateFile);
+
+                using var stream = blob.OpenRead();
+                using var reader = new StreamReader(stream);
+
+                while (!reader.EndOfStream)
+                {
+                    var line = reader.ReadLine().Trim();
+
+                    if (!string.IsNullOrEmpty(line) && !line.StartsWith("#"))
+                    {
+                        result.Add(line, line);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Unexpected error while loading known plate files");
+            }
+
+            logger.LogInformation("Loaded {Count} known plate files", result.Count);
+
+            return result;
+        }
+    }
+}

--- a/src/WWT.Azure/PlateFiles/AzurePlateTilePyramidOptions.cs
+++ b/src/WWT.Azure/PlateFiles/AzurePlateTilePyramidOptions.cs
@@ -10,6 +10,8 @@ namespace WWT.Azure
 
         public bool SkipIfExists { get; set; }
 
+        public string KnownPlateFile { get; set; }
+
         public bool OverwriteExisting { get; set; }
 
         public bool UseAzurePlateFiles { get; set; }

--- a/src/WWT.Azure/Tours/AzureTourAccessor.cs
+++ b/src/WWT.Azure/Tours/AzureTourAccessor.cs
@@ -23,13 +23,15 @@ namespace WWT.Azure
         }
 
         public Task<Stream> GetAuthorThumbnailAsync(string id, CancellationToken token)
-           => GetStream($"{id}_AuthorThumb.bin", token);
+           => GetStream($"{NormalizeId(id)}_AuthorThumb.bin", token);
 
         public Task<Stream> GetTourAsync(string id, CancellationToken token)
-           => GetStream($"{id}.bin", token);
+           => GetStream($"{NormalizeId(id)}.bin", token);
 
         public Task<Stream> GetTourThumbnailAsync(string id, CancellationToken token)
-           => GetStream($"{id}_TourThumb.bin", token);
+           => GetStream($"{NormalizeId(id)}_TourThumb.bin", token);
+
+        private static string NormalizeId(string id) => id.ToLowerInvariant();
 
         private async Task<Stream> GetStream(string name, CancellationToken token)
         {

--- a/src/WWT.PlateFiles/IKnownPlateFiles.cs
+++ b/src/WWT.PlateFiles/IKnownPlateFiles.cs
@@ -1,0 +1,7 @@
+﻿namespace WWT.PlateFiles
+{
+    public interface IKnownPlateFiles
+    {
+        bool TryNormalizePlateName(string input, out string platefile);
+    }
+}

--- a/src/WWT.Providers/Providers/TwoMASSOctProvider.cs
+++ b/src/WWT.Providers/Providers/TwoMASSOctProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Configuration;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/WWT.Providers/Providers/tiles2Provider.cs
+++ b/src/WWT.Providers/Providers/tiles2Provider.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using WWT.PlateFiles;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -9,11 +10,13 @@ namespace WWT.Providers
     public class Tiles2Provider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
+        private readonly IKnownPlateFiles _knownPlateFiles;
         private readonly FilePathOptions _options;
 
-        public Tiles2Provider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public Tiles2Provider(IPlateTilePyramid plateTiles, IKnownPlateFiles knownPlateFiles, FilePathOptions options)
         {
             _plateTiles = plateTiles;
+            _knownPlateFiles = knownPlateFiles;
             _options = options;
         }
 
@@ -24,14 +27,13 @@ namespace WWT.Providers
             int level = Convert.ToInt32(values[0]);
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
-            string file = values[3];
 
             context.Response.AddHeader("Cache-Control", "public, max-age=31536000");
             context.Response.AddHeader("Expires", "Thu, 31 Dec 2009 16:00:00 GMT");
             context.Response.AddHeader("ETag", "155");
             context.Response.AddHeader("Last-Modified", "Tue, 20 May 2008 22:32:37 GMT");
 
-            if (level < 10)
+            if (_knownPlateFiles.TryNormalizePlateName(values[3], out var file) && level < 10)
             {
                 context.Response.ContentType = "image/png";
                 using (Stream s = _plateTiles.GetStream(_options.WwtTilesDir, $"{file}.plate", -1, level, tileX, tileY))

--- a/src/WWT.Providers/Providers/tilesProvider.cs
+++ b/src/WWT.Providers/Providers/tilesProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using WWT.PlateFiles;
 using WWTWebservices;
 
 namespace WWT.Providers
@@ -9,11 +10,13 @@ namespace WWT.Providers
     public class TilesProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
+        private readonly IKnownPlateFiles _knownPlateFiles;
         private readonly FilePathOptions _options;
 
-        public TilesProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public TilesProvider(IPlateTilePyramid plateTiles, IKnownPlateFiles knownPlateFiles, FilePathOptions options)
         {
             _plateTiles = plateTiles;
+            _knownPlateFiles = knownPlateFiles;
             _options = options;
         }
 
@@ -24,19 +27,17 @@ namespace WWT.Providers
             int level = Convert.ToInt32(values[0]);
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
-            string file = values[3];
-            string wwtTilesDir = _options.WwtTilesDir;
 
             context.Response.AddHeader("Cache-Control", "public, max-age=31536000");
             context.Response.AddHeader("Expires", "Thu, 31 Dec 2009 16:00:00 GMT");
             context.Response.AddHeader("ETag", "155");
             context.Response.AddHeader("Last-Modified", "Tue, 20 May 2008 22:32:37 GMT");
 
-            if (level < 8)
+            if (_knownPlateFiles.TryNormalizePlateName(values[3], out var file) && level < 8)
             {
                 context.Response.ContentType = "image/png";
 
-                using (Stream s =_plateTiles.GetStream(wwtTilesDir, $"{file}.plate", level, tileX, tileY))
+                using (Stream s = _plateTiles.GetStream(_options.WwtTilesDir, $"{file}.plate", level, tileX, tileY))
                 {
                     if (s.Length == 0)
                     {

--- a/src/WWTMVC5/Global.asax.cs
+++ b/src/WWTMVC5/Global.asax.cs
@@ -92,6 +92,8 @@ namespace WWTMVC5
                 .AddPlateFiles(options =>
                 {
                     options.UseAzurePlateFiles = ConfigReader<bool>.GetSetting("UseAzurePlateFiles");
+                    options.Container = ConfigurationManager.AppSettings["PlateFileContainer"];
+                    options.KnownPlateFile = ConfigurationManager.AppSettings["KnownPlateFile"];
                 })
                 .AddThumbnails(options =>
                 {

--- a/src/WWTMVC5/Web.config
+++ b/src/WWTMVC5/Web.config
@@ -132,6 +132,8 @@ Content-Type: application/x-wt-->
     <!-- Azure storage access for plate files. Storage account can be a URL or a connection string -->
     <add key="UseAzurePlateFiles" value="false"/>
     <add key="AzurePlateFileStorageAccount" value="https://127.0.0.1:10000/devstoreaccount1"/>
+    <add key="PlateFileContainer" value="coredata"/>
+    <add key="KnownPlateFile" value="known_plate_files.txt"/>
 
     <!-- Thumbnail options -->
     <add key="ThumbnailContainer" value="thumbnails"/>

--- a/tests/WWT.Azure.Tests/AzureKnownPlateFileTests.cs
+++ b/tests/WWT.Azure.Tests/AzureKnownPlateFileTests.cs
@@ -1,0 +1,72 @@
+﻿using AutofacContrib.NSubstitute;
+using AutoFixture;
+using Azure.Storage.Blobs;
+using NSubstitute;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace WWT.Azure.Tests
+{
+    public class AzureKnownPlateFileTests
+    {
+        private readonly Fixture _fixture;
+
+        public AzureKnownPlateFileTests()
+        {
+            _fixture = new Fixture();
+        }
+
+        [Fact]
+        public void BuildsMap()
+        {
+            // Arrange
+            var knownPlates = _fixture.CreateMany<string>(10).ToList();
+            var file = CreateFile(knownPlates);
+            var options = _fixture.Create<AzurePlateTilePyramidOptions>();
+
+            using var mock = AutoSubstitute.Configure()
+                .MakeUnregisteredTypesPerLifetime()
+                .Provide(options)
+                .SubstituteFor<BlobServiceClient>()
+                    .ResolveReturnValue(s => s.GetBlobContainerClient(options.Container))
+                .SubstituteFor<BlobContainerClient>()
+                    .ResolveReturnValue(c => c.GetBlobClient(options.KnownPlateFile))
+                .SubstituteFor<BlobClient>()
+                    .ConfigureSubstitute(b => b.OpenRead().Returns(file))
+                .Build();
+
+            var known = mock.Resolve<AzureKnownPlateFile>();
+
+            var expected = knownPlates[3];
+            var upper = expected.ToUpperInvariant();
+
+            // Act/Assert
+            Assert.True(known.TryNormalizePlateName(expected, out var test1));
+            Assert.Equal(expected, test1);
+
+            Assert.True(known.TryNormalizePlateName(upper, out var test2));
+            Assert.NotEqual(upper, test2);
+            Assert.Equal(expected, test2);
+
+            Assert.False(known.TryNormalizePlateName(_fixture.Create<string>(), out _));
+        }
+
+        private Stream CreateFile(IEnumerable<string> knownPlates)
+        {
+            var ms = new MemoryStream();
+            var writer = new StreamWriter(ms);
+
+            foreach (var plate in knownPlates)
+            {
+                writer.WriteLine(plate);
+            }
+
+            writer.Flush();
+            ms.Position = 0;
+
+            return ms;
+        }
+    }
+}

--- a/tests/WWT.Providers.Tests/HttpAutoSubstituteExtensions.cs
+++ b/tests/WWT.Providers.Tests/HttpAutoSubstituteExtensions.cs
@@ -5,6 +5,8 @@ using NSubstitute.Core;
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using WWT.PlateFiles;
+using WWTWebservices;
 
 namespace WWT.Providers.Tests
 {
@@ -22,16 +24,30 @@ namespace WWT.Providers.Tests
         public static AutoSubstituteBuilder RegisterAfterBuild<T>(this AutoSubstituteBuilder builder, Action<T, IComponentContext> action)
             => builder.ConfigureBuilder(b => b.RegisterBuildCallback(s => action(s.Resolve<T>(), s)));
 
-        public static AutoSubstituteBuilder InitializeProviderTests(this AutoSubstituteBuilder builder)
-            => builder
+        public static AutoSubstituteBuilder InitializeProviderTests(this AutoSubstituteBuilder builder, bool initializeKnownPlateFile = true)
+        {
+            builder
                 .InjectProperties()
-                .MakeUnregisteredTypesPerLifetime()
-                .RegisterAfterBuild<IResponse>((r, _) => r.OutputStream.Returns(new MemoryStream()));
+                .MakeUnregisteredTypesPerLifetime();
 
-        public static AutoSubstituteBuilder ConfigureParameterQ(this AutoSubstituteBuilder builder, int level, int x, int y)
-            => builder.RegisterAfterBuild<IParameters>((p, ctx) => p["Q"].Returns($"{level},{x},{y}"));
+            if (initializeKnownPlateFile)
+            {
+                builder.ConfigureKnownPlateFile(Arg.Any<string>(), true);
+            }
 
-        public static AutoSubstituteBuilder ConfigureParameterQ(this AutoSubstituteBuilder builder, object[] args)
+            builder.RegisterAfterBuild<IResponse>((r, _) => r.OutputStream.Returns(new MemoryStream()));
+
+            return builder;
+        }
+
+        public static AutoSubstituteBuilder ConfigureKnownPlateFile(this AutoSubstituteBuilder builder, string plateFile, bool result)
+            => builder.RegisterAfterBuild<IKnownPlateFiles>((k, _) => k.TryNormalizePlateName(plateFile, out Arg.Any<string>()).Returns(x =>
+            {
+                x[1] = x[0];
+                return result;
+            }));
+
+        public static AutoSubstituteBuilder ConfigureParameterQ(this AutoSubstituteBuilder builder, params object[] args)
         {
             var str = string.Join(",", args);
             return builder.RegisterAfterBuild<IParameters>((p, ctx) => p["Q"].Returns(str));

--- a/tests/WWT.Providers.Tests/TilesProviderTests.cs
+++ b/tests/WWT.Providers.Tests/TilesProviderTests.cs
@@ -1,6 +1,9 @@
-﻿using System;
+﻿using AutofacContrib.NSubstitute;
 using AutoFixture;
+using NSubstitute;
+using System;
 using System.IO;
+using System.Threading.Tasks;
 using WWTWebservices;
 using Xunit;
 
@@ -13,6 +16,27 @@ namespace WWT.Providers.Tests
         public TilesProviderTests()
         {
             _fileName = Fixture.Create<string>();
+        }
+
+        [Fact]
+        public async Task NotKnownPlateFile()
+        {
+            // Arrange
+            var x = Fixture.Create<int>();
+            var y = Fixture.Create<int>();
+
+            using var container = AutoSubstitute.Configure()
+                .InitializeProviderTests(initializeKnownPlateFile: false)
+                .Provide(Options)
+                .ConfigureParameterQ(0, x, y, _fileName)
+                .Build();
+
+            // Act
+            await container.RunProviderTestAsync<Tiles2Provider>();
+
+            // Assert
+            GetStreamFromPlateTilePyramid(container.Resolve<IPlateTilePyramid>().DidNotReceive(), 0, x, y);
+            ExpectedResponseAboveMaxLevel(container.Resolve<IResponse>());
         }
 
         protected override object[] GetParameterQ(int level, int x, int y)


### PR DESCRIPTION
This changes does the following to handle case sensitivty:

- Ensure that the ids for tours are lower case

Tour ids are GUIDs and are already lower cased in storage. This change
ensures that the id passed in lower cased so it will match the storage
entry.

- Add IKnownPlateFiles to limit files exposed by tiles[2].aspx

A file has been placed in `coredata/known_plate_files.txt` that is used
for the known plate files. It is a simple list where each line is a
plate file name. On the current VM, there are 224 files that are exposed
by these endpoints. This class helps ensure only those are exposed, as
well as normalize their casing to what is in the blob.

- Lower cases the thumbnail name and class.

Thumbnails appear to be addressed by inconsistent casing. All thumbnails
will be lowercased in storage. This change lowercases the name that is
searched so it will match once the data is updated.