### PR TITLE
Add a mars-data aware plate tile pyramid

### DIFF
--- a/src/WWT.Azure/AzureOptions.cs
+++ b/src/WWT.Azure/AzureOptions.cs
@@ -7,5 +7,11 @@
         /// If the setting is a URL, we'll use managed identity. Otherwise, we'll expect it to be a connection string.
         /// </summary>
         public string StorageAccount { get; set; }
+
+        /// <summary>
+        /// TODO: The current storage account is a classic storage account and managed identity is not supported
+        /// If the setting is a URL, we'll use managed identity. Otherwise, we'll expect it to be a connection string.
+        /// </summary>
+        public string MarsStorageAccount { get; set; }
     }
 }

--- a/src/WWT.Azure/AzureServiceAccessor.cs
+++ b/src/WWT.Azure/AzureServiceAccessor.cs
@@ -1,0 +1,35 @@
+﻿using Azure.Core;
+using Azure.Storage.Blobs;
+using System;
+
+namespace WWT.Azure
+{
+    public class AzureServiceAccessor
+    {
+        public AzureServiceAccessor(AzureOptions options, TokenCredential credential)
+        {
+            WwtFiles = CreateServiceClient(options.StorageAccount, credential);
+            Mars = CreateServiceClient(options.MarsStorageAccount, credential);
+        }
+
+        public BlobServiceClient WwtFiles { get; set; }
+
+        public BlobServiceClient Mars { get; set; }
+
+        /// <summary>
+        /// Creates a <see cref="BlobServiceClient"/> given a string. If the string is a URI, it is assumed to
+        /// be useable via token (ie Managed Identity). Otherwise, it is assumed to be a connection string.
+        /// </summary>
+        private static BlobServiceClient CreateServiceClient(string storageAccount, TokenCredential credential)
+        {
+            if (Uri.TryCreate(storageAccount, UriKind.Absolute, out var storageUri))
+            {
+                return new BlobServiceClient(storageUri, credential);
+            }
+            else
+            {
+                return new BlobServiceClient(storageAccount);
+            }
+        }
+    }
+}

--- a/src/WWT.Azure/PlateFiles/MarsAwareSeekableAzurePlateTilePyramid.cs
+++ b/src/WWT.Azure/PlateFiles/MarsAwareSeekableAzurePlateTilePyramid.cs
@@ -1,0 +1,57 @@
+﻿using Azure.Storage.Blobs;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using WWTWebservices;
+
+namespace WWT.Azure
+{
+    /// <summary>
+    /// An implementation of <see cref="IPlateTilePyramid"/> that adds awareness of the mars storage account
+    /// </summary>
+    public class MarsAwareSeekableAzurePlateTilePyramid : SeekableAzurePlateTilePyramid
+    {
+        private readonly Func<string, string, BlobClient> _blobRetriever;
+
+        public MarsAwareSeekableAzurePlateTilePyramid(
+            AzurePlateTilePyramidOptions options,
+            AzureServiceAccessor services,
+            ILogger<SeekableAzurePlateTilePyramid> logger)
+            : base(options, services.WwtFiles, logger)
+        {
+            _blobRetriever = BuildLookup(services.Mars);
+        }
+
+        /// <summary>
+        /// Overrides the default behavior to use the mars storage account when needed.
+        /// </summary>
+        protected override BlobClient GetBlob(string pathPrefix, string plateName)
+            => _blobRetriever(pathPrefix, plateName) ?? base.GetBlob(pathPrefix, plateName);
+
+        private static Func<string, string, BlobClient> BuildLookup(BlobServiceClient mars)
+        {
+            var cache = new ConcurrentDictionary<string, BlobClient>();
+
+            var hirise = mars.GetBlobContainerClient("hirise");
+            var moc = mars.GetBlobContainerClient("moc");
+
+            // This maps known prefixes supplied to IPlateTilePyramid that are actually using the mars dataset.
+            var marsCollection = new Dictionary<string, BlobContainerClient>
+            {
+                { @"\\wwt-mars\marsroot\dem\", mars.GetBlobContainerClient("dem") },
+                { @"\\wwtfiles.file.core.windows.net\wwtmars\MarsDem", mars.GetBlobContainerClient("marsdem") },
+                { @"\\wwt-mars\marsroot\hirise", hirise },
+                { @"\\wwt-mars\marsroot\moc", moc },
+                { @"https://marsstage.blob.core.windows.net/hirise", hirise },
+                { @"https://marsstage.blob.core.windows.net/moc", moc },
+                { @"\\wwt-mars\marsroot\MARSBASEMAP", mars.GetBlobContainerClient("marsbasemap") },
+            };
+
+            return (prefix, plateName) =>
+                marsCollection.TryGetValue(prefix, out var marsContainer)
+                ? cache.GetOrAdd(plateName, marsContainer.GetBlobClient)
+                : null;
+        }
+    }
+}

--- a/src/WWT.Azure/PlateFiles/SeekableAzurePlateTilePyramid.cs
+++ b/src/WWT.Azure/PlateFiles/SeekableAzurePlateTilePyramid.cs
@@ -15,7 +15,8 @@ namespace WWT.Azure
     {
         private readonly Func<string, BlobClient> _blobRetriever;
         private readonly BlobContainerClient _container;
-        private readonly ILogger<SeekableAzurePlateTilePyramid> _logger;
+
+        protected readonly ILogger<SeekableAzurePlateTilePyramid> _logger;
 
         public SeekableAzurePlateTilePyramid(AzurePlateTilePyramidOptions options, BlobServiceClient service, ILogger<SeekableAzurePlateTilePyramid> logger)
         {
@@ -26,12 +27,9 @@ namespace WWT.Azure
             _blobRetriever = plateName => cache.GetOrAdd(plateName, _container.GetBlobClient);
         }
 
-        Stream IPlateTilePyramid.GetStream(string pathPrefix, string plateName, int level, int x, int y)
-            => GetStream(plateName, level, x, y);
-
-        public Stream GetStream(string plateName, int level, int x, int y)
+        public Stream GetStream(string pathPrefix, string plateName, int level, int x, int y)
         {
-            var client = _blobRetriever(plateName);
+            var client = GetBlob(pathPrefix, plateName);
 
             try
             {
@@ -55,12 +53,9 @@ namespace WWT.Azure
             }
         }
 
-        Stream IPlateTilePyramid.GetStream(string pathPrefix, string plateName, int tag, int level, int x, int y)
-            => GetStream(plateName, tag, level, x, y);
-
-        public Stream GetStream(string plateName, int tag, int level, int x, int y)
+        public Stream GetStream(string pathPrefix, string plateName, int tag, int level, int x, int y)
         {
-            var client = _blobRetriever(plateName);
+            var client = GetBlob(pathPrefix, plateName);
 
             try
             {
@@ -74,5 +69,8 @@ namespace WWT.Azure
                 return null;
             }
         }
+
+        protected virtual BlobClient GetBlob(string pathPrefix, string plateName)
+             => _blobRetriever(plateName);
     }
 }

--- a/src/WWTMVC5/Global.asax.cs
+++ b/src/WWTMVC5/Global.asax.cs
@@ -88,6 +88,7 @@ namespace WWTMVC5
                 .AddAzureServices(options =>
                 {
                     options.StorageAccount = ConfigurationManager.AppSettings["AzurePlateFileStorageAccount"];
+                    options.MarsStorageAccount = ConfigurationManager.AppSettings["MarsStorageAccount"];
                 })
                 .AddPlateFiles(options =>
                 {


### PR DESCRIPTION
This inherits from the SeekableAzurePlateTilePyramid and will track
using the mars data set for prefixes that are known to be for mars.