### PR TITLE
Revert to old martiantile.aspx with updates

### DIFF
--- a/src/WWT.Azure/AzureWwtExtensions.cs
+++ b/src/WWT.Azure/AzureWwtExtensions.cs
@@ -54,7 +54,7 @@ namespace WWT.Azure
             configure(options);
 
             services.Services.AddSingleton(options);
-            services.Services.AddSingleton<IPlateTilePyramid, MarsAwareSeekableAzurePlateTilePyramid>();
+            services.Services.AddSingleton<IPlateTilePyramid, MarsMolaAwareSeekableAzurePlateTilePyramid>();
             services.Services.AddSingleton<IKnownPlateFiles, AzureKnownPlateFile>();
 
             return services;

--- a/src/WWT.Azure/PlateFiles/MarsMolaAwareSeekableAzurePlateTilePyramid.cs
+++ b/src/WWT.Azure/PlateFiles/MarsMolaAwareSeekableAzurePlateTilePyramid.cs
@@ -1,0 +1,51 @@
+﻿using Azure;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WWT.Azure
+{
+    public class MarsMolaAwareSeekableAzurePlateTilePyramid : MarsAwareSeekableAzurePlateTilePyramid
+    {
+        private readonly BlobContainerClient _container;
+
+        public MarsMolaAwareSeekableAzurePlateTilePyramid(
+            AzurePlateTilePyramidOptions options,
+            AzureServiceAccessor services,
+            ILogger<SeekableAzurePlateTilePyramid> logger)
+            : base(options, services, logger)
+        {
+            _container = services.WwtFiles.GetBlobContainerClient("marsmola");
+        }
+
+        public override Task<Stream> GetStreamAsync(string pathPrefix, string plateName, int level, int x, int y, CancellationToken token)
+        {
+            if (string.Equals(plateName, "marsmola.plate", StringComparison.Ordinal))
+            {
+                return GetMarsMolaStream(level, x, y, token);
+            }
+            else
+            {
+                return base.GetStreamAsync(pathPrefix, plateName, level, x, y, token);
+            }
+        }
+
+        private async Task<Stream> GetMarsMolaStream(int level, int x, int y, CancellationToken token)
+        {
+            var blob = _container.GetBlobClient($"marsmolaL{level}X{x}Y{y}.png");
+
+            try
+            {
+                return await blob.OpenReadAsync(_readOptions, token).ConfigureAwait(false);
+            }
+            catch (RequestFailedException e)
+            {
+                _logger.LogError(e, "Error getting MarsMola stream");
+                return null;
+            }
+        }
+    }
+}

--- a/src/WWT.Azure/PlateFiles/SeekableAzurePlateTilePyramid.cs
+++ b/src/WWT.Azure/PlateFiles/SeekableAzurePlateTilePyramid.cs
@@ -18,7 +18,7 @@ namespace WWT.Azure
         private readonly Func<string, BlobClient> _blobRetriever;
         private readonly BlobContainerClient _container;
 
-        private readonly BlobOpenReadOptions _readOptions = new BlobOpenReadOptions(allowModifications: false)
+        protected readonly BlobOpenReadOptions _readOptions = new BlobOpenReadOptions(allowModifications: false)
         {
             BufferSize = 150 * 1024 // Default to 150kb instead of 4mb. Images are 256x256, and most are less than 150kb
         };
@@ -34,7 +34,7 @@ namespace WWT.Azure
             _blobRetriever = plateName => cache.GetOrAdd(plateName, _container.GetBlobClient);
         }
 
-        public async Task<Stream> GetStreamAsync(string pathPrefix, string plateName, int level, int x, int y, CancellationToken token)
+        public virtual async Task<Stream> GetStreamAsync(string pathPrefix, string plateName, int level, int x, int y, CancellationToken token)
         {
             var client = GetBlob(pathPrefix, plateName);
 


### PR DESCRIPTION
This brings back the logic from the previous martiantile.aspx, but
updates it to use the Azure access patterns.

However, it accesses a platefile via exploded png values, so a layer was
added to the plate tile pyramid accees level to know how to handle that.
I think in the long term, we may want to change this to more of a
pipeline where a chain of IPlateTilePyramid implementations can identify
which platefiles they know how to handle; for now, inheriting is solving
the problem.