### PR TITLE
Add modules for requests for AppInsights

### DIFF
--- a/src/WWT.Caching/AppInsightsDistributedCache.cs
+++ b/src/WWT.Caching/AppInsightsDistributedCache.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Options;
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WWT
+{
+    /// <summary>
+    /// A decorated <see cref="IDistributedCache"/> that enables AppInsights tracking of values being set/retrieved
+    /// </summary>
+    /// <remarks>
+    /// Inspired by discussion here: <see cref="https://stackoverflow.com/questions/49925531/tracking-azure-redis-via-end-to-end-transaction-in-application-insights"/>.
+    /// </remarks>
+    public class AppInsightsDistributedCache : IDistributedCache
+    {
+        private readonly object _sentinal = new object();
+        private readonly TelemetryClient _client;
+        private readonly IDistributedCache _other;
+
+        public AppInsightsDistributedCache(IOptions<TelemetryConfiguration> configuration, IDistributedCache other)
+        {
+            _client = new TelemetryClient(configuration.Value);
+            _other = other;
+        }
+
+        public byte[] Get(string key)
+          => CreateOperationInternal(key, () => new ValueTask<byte[]>(_other.Get(key))).GetAwaiter().GetResult();
+
+        public Task<byte[]> GetAsync(string key, CancellationToken token = default)
+          => CreateOperationInternal(key, async () => await _other.GetAsync(key, default)).AsTask();
+
+        public void Refresh(string key) => throw new System.NotImplementedException();
+
+        public Task RefreshAsync(string key, CancellationToken token = default) => throw new System.NotImplementedException();
+
+        public void Remove(string key) => throw new System.NotImplementedException();
+
+        public Task RemoveAsync(string key, CancellationToken token = default) => throw new System.NotImplementedException();
+
+        public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+            => CreateOperationInternal(key, () =>
+            {
+                _other.Set(key, value, options);
+                return new ValueTask<object>(_sentinal);
+            }).GetAwaiter().GetResult();
+
+        public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+            => CreateOperationInternal(key, async () =>
+            {
+                await _other.SetAsync(key, value, options, token).ConfigureAwait(false);
+                return _sentinal;
+            }).AsTask();
+
+        private async ValueTask<T> CreateOperationInternal<T>(string key, Func<ValueTask<T>> action, [CallerMemberName] string name = null)
+        {
+            var dependency = new DependencyTelemetry()
+            {
+                Type = "Redis",
+                Name = name,
+            };
+
+            dependency.Properties["key"] = key;
+
+            using (_client.StartOperation(dependency))
+            {
+                try
+                {
+                    var result = await action().ConfigureAwait(false);
+                    dependency.Success = true;
+                    return result;
+                }
+                catch (Exception)
+                {
+                    dependency.Success = false;
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/src/WWT.Caching/WWT.Caching.csproj
+++ b/src/WWT.Caching/WWT.Caching.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.15.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.9" />

--- a/src/WWT.Caching/WwtCachingExtensions.cs
+++ b/src/WWT.Caching/WwtCachingExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Swick.Cache;
 using Swick.Cache.Handlers;
 using System;
@@ -35,6 +38,8 @@ namespace WWT
                 {
                     redisOptions.Configuration = options.RedisCacheConnectionString;
                 });
+
+                services.Decorate<IDistributedCache>((other, ctx) => new AppInsightsDistributedCache(ctx.GetRequiredService<IOptions<TelemetryConfiguration>>(), other));
             }
             else
             {

--- a/src/WWTMVC5/ApplicationInsights.config
+++ b/src/WWTMVC5/ApplicationInsights.config
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings">
+  <TelemetryInitializers>
+    <Add Type="Microsoft.ApplicationInsights.DependencyCollector.HttpDependenciesParsingTelemetryInitializer, Microsoft.AI.DependencyCollector" />
+    <Add Type="Microsoft.ApplicationInsights.WindowsServer.AzureRoleEnvironmentTelemetryInitializer, Microsoft.AI.WindowsServer" />
+    <Add Type="Microsoft.ApplicationInsights.WindowsServer.BuildInfoConfigComponentVersionTelemetryInitializer, Microsoft.AI.WindowsServer" />
+    <Add Type="Microsoft.ApplicationInsights.Web.WebTestTelemetryInitializer, Microsoft.AI.Web" />
+    <Add Type="Microsoft.ApplicationInsights.Web.SyntheticUserAgentTelemetryInitializer, Microsoft.AI.Web">
+      <!-- Extended list of bots:
+            search|spider|crawl|Bot|Monitor|BrowserMob|BingPreview|PagePeeker|WebThumb|URL2PNG|ZooShot|GomezA|Google SketchUp|Read Later|KTXN|KHTE|Keynote|Pingdom|AlwaysOn|zao|borg|oegp|silk|Xenu|zeal|NING|htdig|lycos|slurp|teoma|voila|yahoo|Sogou|CiBra|Nutch|Java|JNLP|Daumoa|Genieo|ichiro|larbin|pompos|Scrapy|snappy|speedy|vortex|favicon|indexer|Riddler|scooter|scraper|scrubby|WhatWeb|WinHTTP|voyager|archiver|Icarus6j|mogimogi|Netvibes|altavista|charlotte|findlinks|Retreiver|TLSProber|WordPress|wsr-agent|http client|Python-urllib|AppEngine-Google|semanticdiscovery|facebookexternalhit|web/snippet|Google-HTTP-Java-Client-->
+      <Filters>search|spider|crawl|Bot|Monitor|AlwaysOn</Filters>
+    </Add>
+    <Add Type="Microsoft.ApplicationInsights.Web.ClientIpHeaderTelemetryInitializer, Microsoft.AI.Web" />
+    <Add Type="Microsoft.ApplicationInsights.Web.AzureAppServiceRoleNameFromHostNameHeaderInitializer, Microsoft.AI.Web" />
+    <Add Type="Microsoft.ApplicationInsights.Web.OperationNameTelemetryInitializer, Microsoft.AI.Web" />
+    <Add Type="Microsoft.ApplicationInsights.Web.OperationCorrelationTelemetryInitializer, Microsoft.AI.Web" />
+    <Add Type="Microsoft.ApplicationInsights.Web.UserTelemetryInitializer, Microsoft.AI.Web" />
+    <Add Type="Microsoft.ApplicationInsights.Web.AuthenticatedUserIdTelemetryInitializer, Microsoft.AI.Web" />
+    <Add Type="Microsoft.ApplicationInsights.Web.AccountIdTelemetryInitializer, Microsoft.AI.Web" />
+    <Add Type="Microsoft.ApplicationInsights.Web.SessionTelemetryInitializer, Microsoft.AI.Web" />
+  </TelemetryInitializers>
+  <TelemetryModules>
+    <Add Type="Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule, Microsoft.AI.DependencyCollector">
+      <ExcludeComponentCorrelationHttpHeadersOnDomains>
+        <!-- 
+        Requests to the following hostnames will not be modified by adding correlation headers.         
+        Add entries here to exclude additional hostnames.
+        NOTE: this configuration will be lost upon NuGet upgrade.
+        -->
+        <Add>core.windows.net</Add>
+        <Add>core.chinacloudapi.cn</Add>
+        <Add>core.cloudapi.de</Add>
+        <Add>core.usgovcloudapi.net</Add>
+      </ExcludeComponentCorrelationHttpHeadersOnDomains>
+      <IncludeDiagnosticSourceActivities>
+        <Add>Microsoft.Azure.EventHubs</Add>
+        <Add>Microsoft.Azure.ServiceBus</Add>
+      </IncludeDiagnosticSourceActivities>
+    </Add>
+    <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.PerformanceCollectorModule, Microsoft.AI.PerfCounterCollector">
+      <!--
+      Use the following syntax here to collect additional performance counters:
+      
+      <Counters>
+        <Add PerformanceCounter="\Process(??APP_WIN32_PROC??)\Handle Count" ReportAs="Process handle count" />
+        ...
+      </Counters>
+      
+      PerformanceCounter must be either \CategoryName(InstanceName)\CounterName or \CategoryName\CounterName
+      
+      NOTE: performance counters configuration will be lost upon NuGet upgrade.
+      
+      The following placeholders are supported as InstanceName:
+        ??APP_WIN32_PROC?? - instance name of the application process  for Win32 counters.
+        ??APP_W3SVC_PROC?? - instance name of the application IIS worker process for IIS/ASP.NET counters.
+        ??APP_CLR_PROC?? - instance name of the application CLR process for .NET counters.
+      -->
+    </Add>
+    <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryModule, Microsoft.AI.PerfCounterCollector" />
+    <Add Type="Microsoft.ApplicationInsights.WindowsServer.AppServicesHeartbeatTelemetryModule, Microsoft.AI.WindowsServer" />
+    <Add Type="Microsoft.ApplicationInsights.WindowsServer.AzureInstanceMetadataTelemetryModule, Microsoft.AI.WindowsServer">
+      <!--
+      Remove individual fields collected here by adding them to the ApplicationInsighs.HeartbeatProvider 
+      with the following syntax:
+      
+      <Add Type="Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule, Microsoft.ApplicationInsights">
+        <ExcludedHeartbeatProperties>
+          <Add>osType</Add>
+          <Add>location</Add>
+          <Add>name</Add>
+          <Add>offer</Add>
+          <Add>platformFaultDomain</Add>
+          <Add>platformUpdateDomain</Add>
+          <Add>publisher</Add>
+          <Add>sku</Add>
+          <Add>version</Add>
+          <Add>vmId</Add>
+          <Add>vmSize</Add>
+          <Add>subscriptionId</Add>
+          <Add>resourceGroupName</Add>
+          <Add>placementGroupId</Add>
+          <Add>tags</Add>
+          <Add>vmScaleSetName</Add>
+        </ExcludedHeartbeatProperties>
+      </Add>
+            
+      NOTE: exclusions will be lost upon upgrade.
+      -->
+    </Add>
+    <Add Type="Microsoft.ApplicationInsights.WindowsServer.DeveloperModeWithDebuggerAttachedTelemetryModule, Microsoft.AI.WindowsServer" />
+    <Add Type="Microsoft.ApplicationInsights.WindowsServer.UnhandledExceptionTelemetryModule, Microsoft.AI.WindowsServer" />
+    <Add Type="Microsoft.ApplicationInsights.WindowsServer.UnobservedExceptionTelemetryModule, Microsoft.AI.WindowsServer">
+      <!--</Add>
+    <Add Type="Microsoft.ApplicationInsights.WindowsServer.FirstChanceExceptionStatisticsTelemetryModule, Microsoft.AI.WindowsServer">-->
+    </Add>
+    <Add Type="Microsoft.ApplicationInsights.Web.RequestTrackingTelemetryModule, Microsoft.AI.Web">
+      <Handlers>
+        <!-- 
+        Add entries here to filter out additional handlers: 
+        
+        NOTE: handler configuration will be lost upon NuGet upgrade.
+        -->
+        <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
+        <Add>System.Web.StaticFileHandler</Add>
+        <Add>System.Web.Handlers.AssemblyResourceLoader</Add>
+        <Add>System.Web.Optimization.BundleHandler</Add>
+        <Add>System.Web.Script.Services.ScriptHandlerFactory</Add>
+        <Add>System.Web.Handlers.TraceHandler</Add>
+        <Add>System.Web.Services.Discovery.DiscoveryRequestHandler</Add>
+        <Add>System.Web.HttpDebugHandler</Add>
+      </Handlers>
+    </Add>
+    <Add Type="Microsoft.ApplicationInsights.Web.ExceptionTrackingTelemetryModule, Microsoft.AI.Web" />
+    <Add Type="Microsoft.ApplicationInsights.Web.AspNetDiagnosticTelemetryModule, Microsoft.AI.Web" />
+  </TelemetryModules>
+  <ApplicationIdProvider Type="Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId.ApplicationInsightsApplicationIdProvider, Microsoft.ApplicationInsights" />
+  <TelemetrySinks>
+    <Add Name="default">
+      <TelemetryProcessors>
+        <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
+        <Add Type="Microsoft.ApplicationInsights.Extensibility.AutocollectedMetricsExtractor, Microsoft.ApplicationInsights" />
+        <Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
+          <MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
+          <ExcludedTypes>Event</ExcludedTypes>
+        </Add>
+        <Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
+          <MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
+          <IncludedTypes>Event</IncludedTypes>
+        </Add>
+      </TelemetryProcessors>
+      <TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel" />
+    </Add>
+  </TelemetrySinks>
+</ApplicationInsights>

--- a/src/WWTMVC5/WWTMVC5.csproj
+++ b/src/WWTMVC5/WWTMVC5.csproj
@@ -545,6 +545,9 @@
     <Content Include="Scripts\factory\dataproxy.js" />
     <Content Include="Content\CSS\sprites.less" />
     <Content Include="Content\CSS\multiselect.less" />
+    <Content Include="ApplicationInsights.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="Properties\PublishProfiles\wwt.thewebkid.com.pubxml" />
     <None Include="Properties\PublishProfiles\wwtstaging - FTP.pubxml" />
     <None Include="Properties\PublishProfiles\wwtstaging - Web Deploy.pubxml" />

--- a/src/WWTMVC5/Web.config
+++ b/src/WWTMVC5/Web.config
@@ -78,6 +78,10 @@ Content-Type: application/x-wt-->
       <add name="gettourfile2" verb="*" path="GetTourFile2.aspx" type="WWTMVC5.WwtWebHttpHandler, WWTMVC5" preCondition="managedHandler"/>
     </handlers>
     <modules runAllManagedModulesForAllRequests="false">
+      <remove name="TelemetryCorrelationHttpModule" />
+      <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="managedHandler" />
+      <remove name="ApplicationInsightsWebTracking" />
+      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" />
       <remove name="Session" />
       <add name="Session"
            type="Microsoft.AspNet.SessionState.SessionStateModuleAsync, Microsoft.AspNet.SessionState.SessionStateModule, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"

--- a/tests/WWT.Caching.Tests/ExtensionTests.cs
+++ b/tests/WWT.Caching.Tests/ExtensionTests.cs
@@ -110,7 +110,7 @@ namespace WWT.Caching.Tests
             var resolved = mock.Resolve<IDistributedCache>();
 
             // Assert
-            var inMemory = Assert.IsType<RedisCache>(resolved);
+            var inMemory = Assert.IsType<AppInsightsDistributedCache>(resolved);
         }
 
         public interface ITestService


### PR DESCRIPTION
This updates the code a bit to be more aware of AppInsights:

- It registers two modules for AppInsights so that the current request gets an activity that is used for tracing
- This also ties the tracing into the ILogger<> framework so that log messages are all correlated together.
- Adds a decorator the IDistributedCache to enable tracing in AppInsights

For details on how AppInsights handles correlation, see https://docs.microsoft.com/en-us/azure/azure-monitor/app/correlation

With the change, the logs are all contained within a request and Redis is treated as a dependency:

![image](https://user-images.githubusercontent.com/583206/98194867-33271a00-1ed5-11eb-92f4-212a4e0ecdef.png)
