### PR TITLE
Add TelemetryCorrelationHttpModule to System.Web/httpModules

### DIFF
--- a/src/WWTMVC5/Web.config
+++ b/src/WWTMVC5/Web.config
@@ -44,9 +44,16 @@
              settingsMethodName="GetConnectionString" />
       </providers>
     </sessionState>
+    <httpModules>
+      <add name="TelemetryCorrelationHttpModule"
+           type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"/>
+      <add name="ApplicationInsightsWebTracking"
+           type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web"/>
+    </httpModules>
   </system.web>
 
   <system.webServer>
+    <validation validateIntegratedModeConfiguration="false"/>
     <staticContent>
       <mimeMap fileExtension=".wwtl" mimeType="application/wwtl"/>
       <mimeMap fileExtension=".wtt" mimeType="application/wtt"/>
@@ -79,9 +86,13 @@ Content-Type: application/x-wt-->
     </handlers>
     <modules runAllManagedModulesForAllRequests="false">
       <remove name="TelemetryCorrelationHttpModule" />
-      <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="managedHandler" />
+      <add name="TelemetryCorrelationHttpModule"
+           type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"
+           preCondition="managedHandler" />
       <remove name="ApplicationInsightsWebTracking" />
-      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" />
+      <add name="ApplicationInsightsWebTracking"
+           type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web"
+           preCondition="managedHandler" />
       <remove name="Session" />
       <add name="Session"
            type="Microsoft.AspNet.SessionState.SessionStateModuleAsync, Microsoft.AspNet.SessionState.SessionStateModule, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"


### PR DESCRIPTION
This doesn't seem to be invoked by AppService. Updating to be closer to what a clean install would have.