### PR TITLE
Remove final ConfigurationManager usage

### DIFF
--- a/src/WWT.Providers/Providers/Catalog2provider.cs
+++ b/src/WWT.Providers/Providers/Catalog2provider.cs
@@ -4,7 +4,8 @@ namespace WWT.Providers
 {
     public class Catalog2Provider : CatalogProvider
     {
-        public Catalog2Provider(FilePathOptions options, ICatalogAccessor catalog) : base(options, catalog, true)
+        public Catalog2Provider(ICatalogAccessor catalog)
+            : base(catalog, true)
         {
         }
     }

--- a/src/WWT.Providers/Providers/Catalogprovider.cs
+++ b/src/WWT.Providers/Providers/Catalogprovider.cs
@@ -7,13 +7,11 @@ namespace WWT.Providers
 {
     public class CatalogProvider : RequestProvider
     {
-        private readonly FilePathOptions _options;
         private readonly ICatalogAccessor _catalog;        
         private readonly bool _useXmlContentType;
 
-        public CatalogProvider(FilePathOptions options, ICatalogAccessor catalogAccessor, bool useXmlContentType = false)
+        public CatalogProvider(ICatalogAccessor catalogAccessor, bool useXmlContentType = false)
         {
-            _options = options;
             _catalog = catalogAccessor;
             _useXmlContentType = useXmlContentType;
         }

--- a/src/WWT.Providers/Providers/Demprovider.cs
+++ b/src/WWT.Providers/Providers/Demprovider.cs
@@ -7,9 +7,9 @@ namespace WWT.Providers
 {
     public class DemProvider : RequestProvider
     {
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public DemProvider(FilePathOptions options)
+        public DemProvider(WwtOptions options)
         {
             _options = options;
         }

--- a/src/WWT.Providers/Providers/Demtileprovider.cs
+++ b/src/WWT.Providers/Providers/Demtileprovider.cs
@@ -7,9 +7,9 @@ namespace WWT.Providers
 {
     public class DemTileProvider : RequestProvider
     {
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public DemTileProvider(FilePathOptions options)
+        public DemTileProvider(WwtOptions options)
         {
             _options = options;
         }

--- a/src/WWT.Providers/Providers/Dssprovider.cs
+++ b/src/WWT.Providers/Providers/Dssprovider.cs
@@ -8,9 +8,9 @@ namespace WWT.Providers
     public class DSSProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTile;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public DSSProvider(IPlateTilePyramid plateTile, FilePathOptions options)
+        public DSSProvider(IPlateTilePyramid plateTile, WwtOptions options)
         {
             _plateTile = plateTile;
             _options = options;

--- a/src/WWT.Providers/Providers/Dsstoastprovider.cs
+++ b/src/WWT.Providers/Providers/Dsstoastprovider.cs
@@ -8,9 +8,9 @@ namespace WWT.Providers
     public class DSSToastProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTile;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public DSSToastProvider(IPlateTilePyramid plateTile, FilePathOptions options)
+        public DSSToastProvider(IPlateTilePyramid plateTile, WwtOptions options)
         {
             _plateTile = plateTile;
             _options = options;

--- a/src/WWT.Providers/Providers/Dusttoastprovider.cs
+++ b/src/WWT.Providers/Providers/Dusttoastprovider.cs
@@ -8,9 +8,9 @@ namespace WWT.Providers
     public class DustToastProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public DustToastProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public DustToastProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Earthblendprovider.cs
+++ b/src/WWT.Providers/Providers/Earthblendprovider.cs
@@ -12,10 +12,10 @@ namespace WWT.Providers
     public class EarthBlendProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
         private readonly IVirtualEarthDownloader _veDownloader;
 
-        public EarthBlendProvider(IPlateTilePyramid plateTiles, FilePathOptions options, IVirtualEarthDownloader veDownloader)
+        public EarthBlendProvider(IPlateTilePyramid plateTiles, WwtOptions options, IVirtualEarthDownloader veDownloader)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Earthmerbathprovider.cs
+++ b/src/WWT.Providers/Providers/Earthmerbathprovider.cs
@@ -9,10 +9,10 @@ namespace WWT.Providers
     public class EarthMerBathProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
         private readonly IVirtualEarthDownloader _veDownloader;
 
-        public EarthMerBathProvider(IPlateTilePyramid plateTiles, FilePathOptions options, IVirtualEarthDownloader veDownloader)
+        public EarthMerBathProvider(IPlateTilePyramid plateTiles, WwtOptions options, IVirtualEarthDownloader veDownloader)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/G360provider.cs
+++ b/src/WWT.Providers/Providers/G360provider.cs
@@ -8,9 +8,9 @@ namespace WWT.Providers
     public class G360Provider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public G360Provider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public G360Provider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Galex4farprovider.cs
+++ b/src/WWT.Providers/Providers/Galex4farprovider.cs
@@ -8,9 +8,9 @@ namespace WWT.Providers
     public class Galex4FarProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public Galex4FarProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public Galex4FarProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Galex4nearprovider.cs
+++ b/src/WWT.Providers/Providers/Galex4nearprovider.cs
@@ -8,9 +8,9 @@ namespace WWT.Providers
     public class Galex4NearProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public Galex4NearProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public Galex4NearProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Galextoastprovider.cs
+++ b/src/WWT.Providers/Providers/Galextoastprovider.cs
@@ -8,9 +8,9 @@ namespace WWT.Providers
     public class GalexToastProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public GalexToastProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public GalexToastProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Gettourlist.Aspx.cs
+++ b/src/WWT.Providers/Providers/Gettourlist.Aspx.cs
@@ -11,9 +11,9 @@ namespace WWT.Providers
 {
     public abstract partial class GetTourList : RequestProvider
     {
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public GetTourList(FilePathOptions options)
+        public GetTourList(WwtOptions options)
         {
             _options = options;
         }
@@ -247,14 +247,7 @@ namespace WWT.Providers
 
 
 
-            try
-            {
-                minutesToAdd = Int32.Parse(ConfigurationManager.AppSettings["TourVersionCheckIntervalMinutes"]);
-            }
-            catch
-            {
-                minutesToAdd = 5;  // if missing config, set to 5 minutes
-            }
+            minutesToAdd = _options.TourVersionCheckIntervalMinutes;
 
             if (System.DateTime.Now > fromCacheDateTime.AddMinutes(minutesToAdd))
             {

--- a/src/WWT.Providers/Providers/Gettourlistprovider.cs
+++ b/src/WWT.Providers/Providers/Gettourlistprovider.cs
@@ -5,7 +5,7 @@ namespace WWT.Providers
 {
     public class GetTourListProvider : GetTourList
     {
-        public GetTourListProvider(FilePathOptions options)
+        public GetTourListProvider(WwtOptions options)
             : base(options)
         {
         }

--- a/src/WWT.Providers/Providers/Gettoursprovider.cs
+++ b/src/WWT.Providers/Providers/Gettoursprovider.cs
@@ -9,7 +9,7 @@ namespace WWT.Providers
 {
     public class GetToursProvider : GetTourList
     {
-        public GetToursProvider(FilePathOptions options)
+        public GetToursProvider(WwtOptions options)
             : base(options)
         {
         }

--- a/src/WWT.Providers/Providers/Glimpseprovider.cs
+++ b/src/WWT.Providers/Providers/Glimpseprovider.cs
@@ -9,9 +9,9 @@ namespace WWT.Providers
     public class GlimpseProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public GlimpseProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public GlimpseProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Halphatoastprovider.cs
+++ b/src/WWT.Providers/Providers/Halphatoastprovider.cs
@@ -9,9 +9,9 @@ namespace WWT.Providers
     public class HAlphaToastProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public HAlphaToastProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public HAlphaToastProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Hirisedem2.Aspx.cs
+++ b/src/WWT.Providers/Providers/Hirisedem2.Aspx.cs
@@ -93,9 +93,9 @@ namespace WWT.Providers
         };
 
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public HiriseDem2(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public HiriseDem2(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Hirisedem2provider.cs
+++ b/src/WWT.Providers/Providers/Hirisedem2provider.cs
@@ -8,7 +8,7 @@ namespace WWT.Providers
 {
     public class HiriseDem2Provider : HiriseDem2
     {
-        public HiriseDem2Provider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public HiriseDem2Provider(IPlateTilePyramid plateTiles, WwtOptions options)
             : base(plateTiles, options)
         {
         }

--- a/src/WWT.Providers/Providers/Hirisedem3provider.cs
+++ b/src/WWT.Providers/Providers/Hirisedem3provider.cs
@@ -9,9 +9,9 @@ namespace WWT.Providers
     public class HiriseDem3Provider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public HiriseDem3Provider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public HiriseDem3Provider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Hirisedemprovider.cs
+++ b/src/WWT.Providers/Providers/Hirisedemprovider.cs
@@ -9,9 +9,9 @@ namespace WWT.Providers
     public class HiriseDemProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public HiriseDemProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public HiriseDemProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Jupiterprovider.cs
+++ b/src/WWT.Providers/Providers/Jupiterprovider.cs
@@ -8,9 +8,9 @@ namespace WWT.Providers
     public class JupiterProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public JupiterProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public JupiterProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Loginprovider.cs
+++ b/src/WWT.Providers/Providers/Loginprovider.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Configuration;
 using System.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,6 +7,13 @@ namespace WWT.Providers
 {
     public class LoginProvider : LoginUser
     {
+        private readonly WwtOptions _options;
+
+        public LoginProvider(WwtOptions options)
+        {
+            _options = options;
+        }
+
         public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             context.Response.AddHeader("Cache-Control", "no-cache");
@@ -39,10 +45,10 @@ namespace WWT.Providers
 
             try
             {
-                if (Convert.ToBoolean(ConfigurationManager.AppSettings["LoginTracking"]))
+                if (_options.LoginTracking)
                 {
                     String guid = context.Request.Params["user"];
-                    String con = ConfigurationManager.AppSettings["LoggingConn"];
+                    String con = _options.LoggingConn;
                     String ver = context.Request.Params["version"];
                     SqlConnection myConn = GetConnectionLogging(con);
 

--- a/src/WWT.Providers/Providers/Marsdemprovider.cs
+++ b/src/WWT.Providers/Providers/Marsdemprovider.cs
@@ -7,9 +7,9 @@ namespace WWT.Providers
 {
     public class MarsdemProvider : RequestProvider
     {
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public MarsdemProvider(FilePathOptions options)
+        public MarsdemProvider(WwtOptions options)
         {
             _options = options;
         }

--- a/src/WWT.Providers/Providers/Marshiriseprovider.cs
+++ b/src/WWT.Providers/Providers/Marshiriseprovider.cs
@@ -11,9 +11,9 @@ namespace WWT.Providers
     public class MarsHiriseProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public MarsHiriseProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public MarsHiriseProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Marsmocprovider.cs
+++ b/src/WWT.Providers/Providers/Marsmocprovider.cs
@@ -11,9 +11,9 @@ namespace WWT.Providers
     public class MarsMocProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public MarsMocProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public MarsMocProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Marsprovider.cs
+++ b/src/WWT.Providers/Providers/Marsprovider.cs
@@ -8,9 +8,9 @@ namespace WWT.Providers
     public class MarsProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public MarsProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public MarsProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Martiantile2provider.cs
+++ b/src/WWT.Providers/Providers/Martiantile2provider.cs
@@ -10,9 +10,9 @@ namespace WWT.Providers
     public class MartianTile2Provider : HiRise
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public MartianTile2Provider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public MartianTile2Provider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Mipsgalprovider.cs
+++ b/src/WWT.Providers/Providers/Mipsgalprovider.cs
@@ -9,9 +9,9 @@ namespace WWT.Providers
     public class MipsgalProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public MipsgalProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public MipsgalProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Moondemprovider.cs
+++ b/src/WWT.Providers/Providers/Moondemprovider.cs
@@ -7,9 +7,9 @@ namespace WWT.Providers
 {
     public class MoondemProvider : RequestProvider
     {
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public MoondemProvider(FilePathOptions options)
+        public MoondemProvider(WwtOptions options)
         {
             _options = options;
         }

--- a/src/WWT.Providers/Providers/Moonoctprovider.cs
+++ b/src/WWT.Providers/Providers/Moonoctprovider.cs
@@ -9,9 +9,9 @@ namespace WWT.Providers
     public class MoonOctProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public MoonOctProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public MoonOctProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Moontoastdemprovider.cs
+++ b/src/WWT.Providers/Providers/Moontoastdemprovider.cs
@@ -9,9 +9,9 @@ namespace WWT.Providers
     public class MoontoastdemProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public MoontoastdemProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public MoontoastdemProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Moontoastprovider.cs
+++ b/src/WWT.Providers/Providers/Moontoastprovider.cs
@@ -9,9 +9,9 @@ namespace WWT.Providers
     public class MoontoastProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public MoontoastProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public MoontoastProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Postratingfeedbackprovider.cs
+++ b/src/WWT.Providers/Providers/Postratingfeedbackprovider.cs
@@ -9,9 +9,9 @@ namespace WWT.Providers
 {
     public class PostRatingFeedbackProvider : RequestProvider
     {
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public PostRatingFeedbackProvider(FilePathOptions options)
+        public PostRatingFeedbackProvider(WwtOptions options)
         {
             _options = options;
         }

--- a/src/WWT.Providers/Providers/Rasstoastprovider.cs
+++ b/src/WWT.Providers/Providers/Rasstoastprovider.cs
@@ -8,9 +8,9 @@ namespace WWT.Providers
     public class RassToastProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public RassToastProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public RassToastProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Sdss12toastprovider.cs
+++ b/src/WWT.Providers/Providers/Sdss12toastprovider.cs
@@ -9,10 +9,10 @@ namespace WWT.Providers
     public class SDSS12ToastProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
         private readonly IOctTileMapBuilder _octTileMap;
 
-        public SDSS12ToastProvider(IPlateTilePyramid plateTiles, FilePathOptions options, IOctTileMapBuilder octTileMap)
+        public SDSS12ToastProvider(IPlateTilePyramid plateTiles, WwtOptions options, IOctTileMapBuilder octTileMap)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Sdsstoast2provider.cs
+++ b/src/WWT.Providers/Providers/Sdsstoast2provider.cs
@@ -9,10 +9,10 @@ namespace WWT.Providers
     public class SDSSToast2Provider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
         private readonly IOctTileMapBuilder _octTileMap;
 
-        public SDSSToast2Provider(IPlateTilePyramid plateTiles, FilePathOptions options, IOctTileMapBuilder octTileMap)
+        public SDSSToast2Provider(IPlateTilePyramid plateTiles, WwtOptions options, IOctTileMapBuilder octTileMap)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Sdsstoastprovider.cs
+++ b/src/WWT.Providers/Providers/Sdsstoastprovider.cs
@@ -9,10 +9,10 @@ namespace WWT.Providers
     public class SDSSToastProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
         private readonly IOctTileMapBuilder _octTileMap;
 
-        public SDSSToastProvider(IPlateTilePyramid plateTiles, FilePathOptions options, IOctTileMapBuilder octTileMap)
+        public SDSSToastProvider(IPlateTilePyramid plateTiles, WwtOptions options, IOctTileMapBuilder octTileMap)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Testfailoverprovider.cs
+++ b/src/WWT.Providers/Providers/Testfailoverprovider.cs
@@ -5,9 +5,9 @@ namespace WWT.Providers
 {
     public class TestfailoverProvider : RequestProvider
     {
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public TestfailoverProvider(FilePathOptions options)
+        public TestfailoverProvider(WwtOptions options)
         {
             _options = options;
         }

--- a/src/WWT.Providers/Providers/Testprovider.cs
+++ b/src/WWT.Providers/Providers/Testprovider.cs
@@ -6,9 +6,9 @@ namespace WWT.Providers
 {
     public class TestProvider : RequestProvider
     {
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public TestProvider(FilePathOptions options)
+        public TestProvider(WwtOptions options)
         {
             _options = options;
         }

--- a/src/WWT.Providers/Providers/Tiles2provider.cs
+++ b/src/WWT.Providers/Providers/Tiles2provider.cs
@@ -11,9 +11,9 @@ namespace WWT.Providers
     {
         private readonly IPlateTilePyramid _plateTiles;
         private readonly IKnownPlateFiles _knownPlateFiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public Tiles2Provider(IPlateTilePyramid plateTiles, IKnownPlateFiles knownPlateFiles, FilePathOptions options)
+        public Tiles2Provider(IPlateTilePyramid plateTiles, IKnownPlateFiles knownPlateFiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _knownPlateFiles = knownPlateFiles;

--- a/src/WWT.Providers/Providers/Tilesprovider.cs
+++ b/src/WWT.Providers/Providers/Tilesprovider.cs
@@ -11,9 +11,9 @@ namespace WWT.Providers
     {
         private readonly IPlateTilePyramid _plateTiles;
         private readonly IKnownPlateFiles _knownPlateFiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public TilesProvider(IPlateTilePyramid plateTiles, IKnownPlateFiles knownPlateFiles, FilePathOptions options)
+        public TilesProvider(IPlateTilePyramid plateTiles, IKnownPlateFiles knownPlateFiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _knownPlateFiles = knownPlateFiles;

--- a/src/WWT.Providers/Providers/Twomassoctprovider.cs
+++ b/src/WWT.Providers/Providers/Twomassoctprovider.cs
@@ -9,9 +9,9 @@ namespace WWT.Providers
     public class TwoMASSOctProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public TwoMASSOctProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public TwoMASSOctProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Twomasstoastprovider.cs
+++ b/src/WWT.Providers/Providers/Twomasstoastprovider.cs
@@ -9,9 +9,9 @@ namespace WWT.Providers
     public class TwoMassToastProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public TwoMassToastProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public TwoMassToastProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Tychooctprovider.cs
+++ b/src/WWT.Providers/Providers/Tychooctprovider.cs
@@ -9,9 +9,9 @@ namespace WWT.Providers
     public class TychoOctProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public TychoOctProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public TychoOctProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Vlsstoastprovider.cs
+++ b/src/WWT.Providers/Providers/Vlsstoastprovider.cs
@@ -9,9 +9,9 @@ namespace WWT.Providers
     public class VlssToastProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public VlssToastProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public VlssToastProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Weblogin.Aspx.cs
+++ b/src/WWT.Providers/Providers/Weblogin.Aspx.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Configuration;
 using System.Data;
 using System.Data.SqlClient;
 
@@ -7,16 +6,23 @@ namespace WWT.Providers
 {
     public abstract partial class LoginWebUser : RequestProvider
     {
-        internal static SqlConnection GetConnectionLogging()
+        protected readonly WwtOptions _options;
+
+        public LoginWebUser(WwtOptions options)
+        {
+            _options = options;
+        }
+
+        internal SqlConnection GetConnectionLogging()
         {
             string connStr = null;
-            connStr = ConfigurationManager.AppSettings["LoggingConn"];
+            connStr = _options.LoggingConn;
             SqlConnection myConnection = null;
             myConnection = new SqlConnection(connStr);
             return myConnection;
         }
 
-        public static string PostFeedback(string GUID, byte type)
+        public string PostFeedback(string GUID, byte type)
         {
             // type 1 = Windows client
             // type 2 = Web Client

--- a/src/WWT.Providers/Providers/Webloginprovider.cs
+++ b/src/WWT.Providers/Providers/Webloginprovider.cs
@@ -7,18 +7,23 @@ namespace WWT.Providers
 {
     public class WebloginProvider : LoginWebUser
     {
+        public WebloginProvider(WwtOptions options)
+            : base(options)
+        {
+        }
+
         public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
             context.Response.AddHeader("Cache-Control", "no-cache");
             context.Response.Expires = -1;
             context.Response.CacheControl = "no-cache";
 
-            string key = ConfigurationManager.AppSettings["webkey"];
+            string key = _options.Webkey;
             string testkey = context.Request.Params["webkey"];
             if (key == testkey)
             {
                 context.Response.Write("Key:Authorized");
-                if (Convert.ToBoolean(ConfigurationManager.AppSettings["LoginTracking"]))
+                if (_options.LoginTracking)
                 {
                     byte platform = 2;
                     if (context.Request.Params["Version"] != null)

--- a/src/WWT.Providers/Providers/Wmapprovider.cs
+++ b/src/WWT.Providers/Providers/Wmapprovider.cs
@@ -9,9 +9,9 @@ namespace WWT.Providers
     public class WmapProvider : RequestProvider
     {
         private readonly IPlateTilePyramid _plateTiles;
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public WmapProvider(IPlateTilePyramid plateTiles, FilePathOptions options)
+        public WmapProvider(IPlateTilePyramid plateTiles, WwtOptions options)
         {
             _plateTiles = plateTiles;
             _options = options;

--- a/src/WWT.Providers/Providers/Xml2wttprovider.cs
+++ b/src/WWT.Providers/Providers/Xml2wttprovider.cs
@@ -7,9 +7,9 @@ namespace WWT.Providers
 {
     public class XML2WTTProvider : WWTWeb_XML2WTT
     {
-        private readonly FilePathOptions _options;
+        private readonly WwtOptions _options;
 
-        public XML2WTTProvider(IFileNameHasher hasher, FilePathOptions options)
+        public XML2WTTProvider(IFileNameHasher hasher, WwtOptions options)
             : base(hasher)
         {
             _options = options;

--- a/src/WWT.Providers/RequestProvidersExtensions.cs
+++ b/src/WWT.Providers/RequestProvidersExtensions.cs
@@ -12,7 +12,7 @@ namespace WWT.Providers
 {
     public static class RequestProvidersExtensions
     {
-        public static void AddRequestProviders(this IServiceCollection services, Action<FilePathOptions> config)
+        public static void AddRequestProviders(this IServiceCollection services, Action<WwtOptions> config)
         {
             var types = typeof(RequestProvider).Assembly.GetTypes()
                 .Where(t => !t.IsAbstract && typeof(RequestProvider).IsAssignableFrom(t));
@@ -26,7 +26,7 @@ namespace WWT.Providers
             services.AddSingleton<IMandelbrot, Mandelbrot>();
             services.AddSingleton<IVirtualEarthDownloader, VirtualEarthDownloader>();
 
-            var options = new FilePathOptions();
+            var options = new WwtOptions();
 
             config(options);
 

--- a/src/WWT.Providers/WWT.Providers.csproj
+++ b/src/WWT.Providers/WWT.Providers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
@@ -25,10 +25,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.9" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Configuration" />
   </ItemGroup>
 
 </Project>

--- a/src/WWT.Providers/WwtOptions.cs
+++ b/src/WWT.Providers/WwtOptions.cs
@@ -1,9 +1,15 @@
-﻿using System;
-
-namespace WWT.Providers
+﻿namespace WWT.Providers
 {
-    public class FilePathOptions
+    public class WwtOptions
     {
+        public int TourVersionCheckIntervalMinutes { get; set; }
+
+        public bool LoginTracking { get; set; }
+
+        public string LoggingConn { get; set; }
+
+        public string Webkey { get; set; }
+
         public string DataDir { get; set; }
 
         public string DssTerapixelDir { get; set; }

--- a/src/WWTMVC5/Global.asax.cs
+++ b/src/WWTMVC5/Global.asax.cs
@@ -85,6 +85,11 @@ namespace WWTMVC5
                 options.WwtGalexDir = ConfigurationManager.AppSettings["WWTGALEXDIR"];
                 options.WwtToursDBConnectionString = ConfigurationManager.AppSettings["WWTToursDBConnectionString"];
                 options.WwtTourCache = ConfigurationManager.AppSettings["WWTTOURCACHE"];
+
+                options.TourVersionCheckIntervalMinutes = int.TryParse(ConfigurationManager.AppSettings["TourVersionCheckIntervalMinutes"], out var min) ? min : 5;
+                options.LoginTracking = Convert.ToBoolean(ConfigurationManager.AppSettings["LoginTracking"]);
+                options.LoggingConn = ConfigurationManager.AppSettings["LoggingConn"];
+                options.Webkey = ConfigurationManager.AppSettings["webkey"];
             });
 
             services

--- a/tests/WWT.Providers.Tests/Providertests.cs
+++ b/tests/WWT.Providers.Tests/Providertests.cs
@@ -17,12 +17,12 @@ namespace WWT.Providers.Tests
         public ProviderTests()
         {
             Fixture = new Fixture();
-            Options = Fixture.Create<FilePathOptions>();
+            Options = Fixture.Create<WwtOptions>();
         }
 
         protected Fixture Fixture { get; }
 
-        protected FilePathOptions Options { get; }
+        protected WwtOptions Options { get; }
 
         protected virtual int MaxLevel => -1;
 


### PR DESCRIPTION
This also renames the FilePathOptions type to WwtOptions as this is more of a general options type and not just for files.

This change also allows us to retarget .NET Standard in the providers assembly. It can now be referenced in a .NET Core app