### PR TITLE
azure-pipelines.yml: attempt to fix deployment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,5 +129,5 @@ steps:
     deployToSlotOrASE: true
     ResourceGroupName: 'wwtcoreapp-resources'
     SlotName: 'production'
-    packageForLinux: '$(Build.artifactStagingDirectory)/website/*.zip'
+    packageForLinux: '$(Build.artifactStagingDirectory)/website/WWTMVC5.zip'
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))


### PR DESCRIPTION
App Service deployment currently failing:

```
##[error]Error: More than one package matched with specified pattern: D:\a\1\a\website\*.zip. Please restrain the search pattern.
```

There is a WWTMVC5.zip but also a WWT.Web.zip in the website artifact directory.