### PR TITLE
Update to .NET 5 wave of libraries

### DIFF
--- a/src/WWT.Azure/WWT.Azure.csproj
+++ b/src/WWT.Azure/WWT.Azure.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.2.3" />
+    <PackageReference Include="Azure.Identity" Version="1.3.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.7.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.9" />
-    <PackageReference Include="System.Linq.Async" Version="4.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WWT.Caching/WWT.Caching.csproj
+++ b/src/WWT.Caching/WWT.Caching.csproj
@@ -11,12 +11,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.15.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.9" />
-    <PackageReference Include="Scrutor" Version="3.2.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.16.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Scrutor" Version="3.3.0" />
     <PackageReference Include="Swick.Cache" Version="0.4.2" />
   </ItemGroup>
 

--- a/src/WWT.Imaging/WWT.Imaging.csproj
+++ b/src/WWT.Imaging/WWT.Imaging.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/WWT.PlateFiles/WWT.PlateFiles.csproj
+++ b/src/WWT.PlateFiles/WWT.PlateFiles.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/WWT.Providers/WWT.Providers.csproj
+++ b/src/WWT.Providers/WWT.Providers.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/src/WWT.Web/WWT.Web.csproj
+++ b/src/WWT.Web/WWT.Web.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.0.2" />
-    <PackageReference Include="Azure.Identity" Version="1.2.3" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.1" />
+    <PackageReference Include="Azure.Identity" Version="1.3.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.16.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.7.3" />
   </ItemGroup>
 

--- a/src/WWTMVC5/WWTMVC5.csproj
+++ b/src/WWTMVC5/WWTMVC5.csproj
@@ -702,7 +702,7 @@
       <Version>3.3.1</Version>
     </PackageReference>
     <PackageReference Include="Azure.Identity">
-      <Version>1.2.3</Version>
+      <Version>1.3.0</Version>
     </PackageReference>
     <PackageReference Include="bootstrap">
       <Version>3.4.1</Version>
@@ -723,28 +723,28 @@
       <Version>5.6.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>2.15.0</Version>
+      <Version>2.16.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.Agent.Intercept">
       <Version>2.4.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector">
-      <Version>2.15.0</Version>
+      <Version>2.16.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector">
-      <Version>2.15.0</Version>
+      <Version>2.16.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector">
       <Version>1.3.7.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.Web">
-      <Version>2.15.0</Version>
+      <Version>2.16.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer">
-      <Version>2.15.0</Version>
+      <Version>2.16.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel">
-      <Version>2.15.0</Version>
+      <Version>2.16.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.Identity.EntityFramework">
       <Version>2.2.1</Version>
@@ -756,7 +756,7 @@
       <Version>1.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.KeyVault.Core">
-      <Version>2.0.4</Version>
+      <Version>3.0.5</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Bcl">
       <Version>1.1.10</Version>
@@ -777,13 +777,13 @@
       <Version>5.8.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
-      <Version>3.1.9</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights">
-      <Version>2.15.0</Version>
+      <Version>2.16.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug">
-      <Version>3.1.9</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel">
       <Version>6.1.7600.16394</Version>

--- a/src/WWTMVC5/Web.config
+++ b/src/WWTMVC5/Web.config
@@ -225,98 +225,98 @@ Content-Type: application/x-wt-->
   </entityFramework>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Spatial" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.8.3.0" newVersion="5.8.3.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Caching.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.8.3.0" newVersion="5.8.3.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.8.3.0" newVersion="5.8.3.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.8.3.0" newVersion="5.8.3.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-2.16.0.18277" newVersion="2.16.0.18277"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Azure.Identity" publicKeyToken="92742159E12E44C8" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Azure.Core" publicKeyToken="92742159E12E44C8" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-1.6.0.0" newVersion="1.6.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Antlr3.Runtime" publicKeyToken="EB42632606E9261F" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
-			</dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="EB42632606E9261F" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Azure.Core" publicKeyToken="92742159E12E44C8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.6.0.0" newVersion="1.6.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Azure.Identity" publicKeyToken="92742159E12E44C8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.16.0.18277" newVersion="2.16.0.18277" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.3.0" newVersion="5.8.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.3.0" newVersion="5.8.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.3.0" newVersion="5.8.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Caching.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Spatial" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.3.0" newVersion="5.8.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/WWTMVC5/Web.config
+++ b/src/WWTMVC5/Web.config
@@ -314,6 +314,10 @@ Content-Type: application/x-wt-->
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
       </dependentAssembly>

--- a/src/WWTMVC5/Web.config
+++ b/src/WWTMVC5/Web.config
@@ -226,105 +226,97 @@ Content-Type: application/x-wt-->
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
+				<assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Spatial" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.8.3.0" newVersion="5.8.3.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
+				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
+				<assemblyIdentity name="Microsoft.Extensions.Caching.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
 			</dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Caching.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.16.1.0" newVersion="4.16.1.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Azure.Identity" publicKeyToken="92742159E12E44C8" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.2.3.0" newVersion="1.2.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Azure.Core" publicKeyToken="92742159E12E44C8" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.6.0.0" newVersion="1.6.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Spatial" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.8.3.0" newVersion="5.8.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.8.3.0" newVersion="5.8.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.8.3.0" newVersion="5.8.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.8.3.0" newVersion="5.8.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="EB42632606E9261F" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
-      </dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.8.3.0" newVersion="5.8.3.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.8.3.0" newVersion="5.8.3.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.8.3.0" newVersion="5.8.3.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-2.16.0.18277" newVersion="2.16.0.18277"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Azure.Identity" publicKeyToken="92742159E12E44C8" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Azure.Core" publicKeyToken="92742159E12E44C8" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-1.6.0.0" newVersion="1.6.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Antlr3.Runtime" publicKeyToken="EB42632606E9261F" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
+			</dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/tests/Directory.Build.Targets
+++ b/tests/Directory.Build.Targets
@@ -6,11 +6,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutofacContrib.NSubstitute" Version="6.2.2" />
+    <PackageReference Include="AutofacContrib.NSubstitute" Version="6.2.3" />
     <PackageReference Include="AutoFixture" Version="4.14.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/tools/PlateManager/PlateManager.csproj
+++ b/tools/PlateManager/PlateManager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>wwt</ToolCommandName>
     <PackageId>wwt</PackageId>
@@ -10,17 +10,17 @@
 
   <ItemGroup>
     <PackageReference Include="Open.ChannelExtensions" Version="3.5.0" />
-    <PackageReference Include="Azure.Identity" Version="1.2.3" />
+    <PackageReference Include="Azure.Identity" Version="1.3.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20371.2" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20371.2" />
-    <PackageReference Include="System.Linq.Async" Version="4.1.1" />
+    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Now that we're moving towards support .NET 5, this will update all usage of the 3.1 wave to 5. The .NET 5 app would already be using the new libraries, so now the WWTMVC5 app will as well.

This also updates the Redis library which should help with the exceptions we've been seeing under load.

Fixes #221