### PR TITLE
Configuration for NetFx/MVC and the NET5 app for Snapshot Debugger

### DIFF
--- a/src/WWT.Web/Startup.cs
+++ b/src/WWT.Web/Startup.cs
@@ -103,8 +103,7 @@ namespace WWT.Web
                 builder.AddDebug();
             });
 
-            services.AddSnapshotCollector((snapshotConfiguration) => 
-                _configuration.Bind(nameof(SnapshotCollectorConfiguration), snapshotConfiguration));
+            services.AddSnapshotCollector();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/WWT.Web/Startup.cs
+++ b/src/WWT.Web/Startup.cs
@@ -1,3 +1,4 @@
+using Microsoft.ApplicationInsights.SnapshotCollector;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -101,6 +102,9 @@ namespace WWT.Web
                 builder.AddFilter("Swick.Cache", LogLevel.Trace);
                 builder.AddDebug();
             });
+
+            services.AddSnapshotCollector((snapshotConfiguration) => 
+                _configuration.Bind(nameof(SnapshotCollectorConfiguration), snapshotConfiguration));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/WWT.Web/WWT.Web.csproj
+++ b/src/WWT.Web/WWT.Web.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.0.2" />
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.7.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WWTMVC5/ApplicationInsights.config
+++ b/src/WWTMVC5/ApplicationInsights.config
@@ -127,6 +127,20 @@
           <MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
           <IncludedTypes>Event</IncludedTypes>
         </Add>
+        <Add Type="Microsoft.ApplicationInsights.SnapshotCollector.SnapshotCollectorTelemetryProcessor, Microsoft.ApplicationInsights.SnapshotCollector">
+          <IsEnabled>true</IsEnabled>
+          <IsEnabledInDeveloperMode>false</IsEnabledInDeveloperMode>
+          <ThresholdForSnapshotting>1</ThresholdForSnapshotting>
+          <MaximumSnapshotsRequired>3</MaximumSnapshotsRequired>
+          <MaximumCollectionPlanSize>50</MaximumCollectionPlanSize>
+          <ReconnectInterval>00:15:00</ReconnectInterval>
+          <ProblemCounterResetInterval>1.00:00:00</ProblemCounterResetInterval>
+          <SnapshotsPerTenMinutesLimit>5</SnapshotsPerTenMinutesLimit>
+          <SnapshotsPerDayLimit>30</SnapshotsPerDayLimit>
+          <SnapshotInLowPriorityThread>true</SnapshotInLowPriorityThread>
+          <ProvideAnonymousTelemetry>true</ProvideAnonymousTelemetry>
+          <FailedRequestLimit>5</FailedRequestLimit>
+        </Add>
       </TelemetryProcessors>
       <TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel" />
     </Add>

--- a/src/WWTMVC5/Global.asax.cs
+++ b/src/WWTMVC5/Global.asax.cs
@@ -159,7 +159,6 @@ namespace WWTMVC5
                 }
             });
 
-
             return services.BuildServiceProvider();
         }
 

--- a/src/WWTMVC5/Global.asax.cs
+++ b/src/WWTMVC5/Global.asax.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.ApplicationInsights;
+using Microsoft.ApplicationInsights.SnapshotCollector;
 using Microsoft.Extensions.Options;
 using System;
 using System.Configuration;
@@ -157,6 +158,7 @@ namespace WWTMVC5
                     TelemetryConfiguration.Active.InstrumentationKey = appInsightsKey;
                 }
             });
+
 
             return services.BuildServiceProvider();
         }

--- a/src/WWTMVC5/WWTMVC5.csproj
+++ b/src/WWTMVC5/WWTMVC5.csproj
@@ -734,6 +734,9 @@
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector">
       <Version>2.15.0</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector">
+      <Version>1.3.7.3</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.Web">
       <Version>2.15.0</Version>
     </PackageReference>


### PR DESCRIPTION
Since we're using a programmatic approach to setting up Application Insights, we have to wire up the configuration settings.