### PR TITLE
Add error catching for out of range platefile index

### DIFF
--- a/src/WWT.PlateFiles/PlateFile2.cs
+++ b/src/WWT.PlateFiles/PlateFile2.cs
@@ -365,7 +365,7 @@ namespace WWTWebservices
 
                 if ((de.x == x) && (de.y == y) && ((de.tag == tag) || (tag == -1)) && (de.level == level))
                 {
-                    return new StreamSlice(dataStream, de.location, de.size);
+                    return StreamSlice.Create(dataStream, de.location, de.size);
                 }
                 else
                 {

--- a/src/WWT.PlateFiles/PlateTileException.cs
+++ b/src/WWT.PlateFiles/PlateTileException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace WWT.PlateFiles
+{
+    public class PlateTileException : Exception
+    {
+        public PlateTileException(string message)
+            : base(message)
+        {
+        }
+
+        public PlateTileException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/WWT.PlateFiles/PlateTilePyramid.cs
+++ b/src/WWT.PlateFiles/PlateTilePyramid.cs
@@ -187,7 +187,6 @@ namespace WWTWebservices
 
         }
 
-
         public static async Task<Stream> GetImageStreamAsync(Stream f, int level, int x, int y, CancellationToken token)
         {
             var offset = GetFileIndexOffset(level, x, y);
@@ -195,7 +194,7 @@ namespace WWTWebservices
 
             var (start, length) = await GetNodeInfoAsync(f, offset, token).ConfigureAwait(false);
 
-            return new StreamSlice(f, start, length);
+            return StreamSlice.Create(f, start, length);
         }
 
         public static Stream GetFileStream(string filename, int level, int x, int y)

--- a/src/WWT.PlateFiles/StreamSlice.cs
+++ b/src/WWT.PlateFiles/StreamSlice.cs
@@ -16,6 +16,22 @@ namespace WWT.PlateFiles
 
         private readonly long _length;
 
+        /// <summary>
+        /// Attempts to create a <see cref="StreamSlice"/>. Any exception is wrapped in
+        /// a <see cref=" PlateTileException"/>.
+        /// </summary>
+        public static Stream Create(Stream baseStream, long offset, long length)
+        {
+            try
+            {
+                return new StreamSlice(baseStream, offset, length);
+            }
+            catch (Exception e)
+            {
+                throw new PlateTileException(e.Message, e);
+            }
+        }
+
         public StreamSlice(Stream baseStream, long offset, long length)
         {
             _baseStream = baseStream ?? throw new ArgumentNullException(nameof(baseStream));


### PR DESCRIPTION
Currently, if an image is being attempted to be grabbed from within a platefile but its indexes don't exist, the request will fail with a 500. This adds exception handling that can be caught, logged, and then null returned rather than bubbling up as an uncaught exception.

Related: #226 