### PR TITLE
Attempt to fix publishing on Linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,7 +166,7 @@ stages:
         displayName: Push tools to feed
         inputs:
           command: 'push'
-          packagesToPush: '$(Pipeline.Workspace)/{tools}/*.nupkg'
+          packagesToPush: '$(Pipeline.Workspace)/tools/*.nupkg'
           nuGetFeedType: 'internal'
           publishVstsFeed: '5b8413f0-309f-4655-933b-c3b9516cd60f/cec2a436-ea5b-41d3-a4d4-8f2380a4c6a9'
 
@@ -188,4 +188,4 @@ stages:
           deployToSlotOrASE: true
           ResourceGroupName: 'wwtcoreapp-resources'
           SlotName: 'stage'
-          packageForLinux: '$(Pipeline.Workspace)/{mvc5}/WWTMVC5.zip'
+          packageForLinux: '$(Pipeline.Workspace)/mvc5/WWTMVC5.zip'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,7 @@ stages:
       displayName: '.NET 5 WebApp'
       pool:
         vmImage: 'Ubuntu-latest'
+
       steps:
       - task: UseDotNet@2
         inputs:
@@ -41,18 +42,21 @@ stages:
           arguments: '/output buildserver /nofetch'
 
       - task: DotNetCoreCLI@2
+        displayName: dotnet build
         inputs:
           command: 'build'
           projects: 'wwt-website-net5.slnf'
           arguments: '--configuration $(buildConfiguration)'
-        
+
       - task: DotNetCoreCLI@2
+        displayName: dotnet test
         inputs:
           command: 'test'
           projects: 'wwt-website-net5.slnf'
           arguments: '--configuration $(buildConfiguration)'
 
       - task: DotNetCoreCLI@2
+        displayName: dotnet publish
         inputs:
           command: 'publish'
           publishWebProjects: false
@@ -60,19 +64,21 @@ stages:
           modifyOutputPath: true
           projects: 'src/WWT.Web/WWT.Web.csproj'
           arguments: '--configuration $(buildConfiguration) -o $(Build.ArtifactStagingDirectory)/website'
-      
+
       - task: DotNetCoreCLI@2
         displayName: Create tool package
         inputs:
           command: 'pack'
           packagesToPack: 'tools/PlateManager/PlateManager.csproj'
           packDirectory: '$(Build.ArtifactStagingDirectory)/tools'
-          versioningScheme: 'off'          
-          
+          versioningScheme: 'off'
+
       - publish: $(build.artifactStagingDirectory)/tools
+        displayName: Publish tools
         artifact: tools
 
       - publish: $(build.artifactStagingDirectory)/website
+        displayName: Publish net5-web
         artifact: net5-web
 
     - job: BuildMVC5

--- a/src/WWT.PlateFiles/WWT.PlateFiles.csproj
+++ b/src/WWT.PlateFiles/WWT.PlateFiles.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/WWT.Tests.props
+++ b/tests/WWT.Tests.props
@@ -2,8 +2,8 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows'">net5;net48</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows'">net5</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows'">net5.0;net48</TargetFrameworks>
+    <TargetFramework Condition=" '$(OS)' != 'Windows'">net5.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
The `dotnet publish` command was failing with messages like:

```
error NETSDK1005: Assets file '/app/src/WWT.Maps/obj/project.assets.json'
  doesn't have a target for 'net5'. Ensure that restore has run and that
  you have included 'net5' in the TargetFrameworks for your project.
  [/app/src/WWT.Maps/WWT.Maps.csproj]
```

This happens even though `dotnet build` is happy. Here I've emulated the approach used in the `tests` directory, monkey-see-monkey-do. We'll see if it causes any problems for the Windows build ...