### PR TITLE
Avoid some annoying 404's in the WWT.Web server

### DIFF
--- a/src/WWT.Web/HelloWorldProvider.cs
+++ b/src/WWT.Web/HelloWorldProvider.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WWT.Providers
+{
+    public class HelloWorldProvider : RequestProvider
+    {
+        public override string ContentType => ContentTypes.Text;
+
+        public override bool IsCacheable => true;
+
+        public override async Task RunAsync(IWwtContext context, CancellationToken token)
+        {
+            string assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            string reply = $"WWT.Web app version {assemblyVersion}\n";
+            await context.Response.WriteAsync(reply, token);
+        }
+    }
+}

--- a/src/WWT.Web/Startup.cs
+++ b/src/WWT.Web/Startup.cs
@@ -106,6 +106,8 @@ namespace WWT.Web
             });
 
             services.AddSnapshotCollector();
+
+            services.AddSingleton(typeof(HelloWorldProvider));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -133,6 +135,20 @@ namespace WWT.Web
 
             var @public = new CacheControlHeaderValue { Public = true };
             var nocache = new CacheControlHeaderValue { NoCache = true };
+
+            // Some special infrastructure endpoints that don't need to be
+            // library-ified:
+            //
+            // Many web infra health checks assume that your server will return
+            // a 200 result for the root path, so let's make sure that actually
+            // happens.
+            endpointManager.Add("/", typeof(HelloWorldProvider));
+
+            // this URL is requested by the Azure App Service Docker framework
+            // to check if the container is running. Azure doesn't care if it
+            // 404's, but those 404's do get logged as failures in Application
+            // Insights, which we'd like to avoid.
+            endpointManager.Add("/robots933456.txt", typeof(HelloWorldProvider));
 
             foreach (var (endpoint, providerType) in endpointManager)
             {


### PR DESCRIPTION
It turns out that the Azure Docker service checks a URL named `/robots933456.txt` to test whether the container is ready to handle requests. The service doesn't care if its requests yield 404s, but those 404's do get logged to App Insights, which we'd prefer to avoid.

While we're at it, we stop returning 404's for requests to "/", since many web infrastructure pieces assume that your app will return a success code for requests to the root (including App Gateway's health checks).