### PR TITLE
Mop up some awaits that don't pass around the cancellation token

### DIFF
--- a/src/WWT.Azure/Imaging/AzureThumbnailAccessor.cs
+++ b/src/WWT.Azure/Imaging/AzureThumbnailAccessor.cs
@@ -46,7 +46,7 @@ namespace WWT.Azure
                 return null;
             }
 
-            return await blob.OpenReadAsync(_blobOpenReadOptions).ConfigureAwait(false);
+            return await blob.OpenReadAsync(_blobOpenReadOptions, token).ConfigureAwait(false);
         }
     }
 }

--- a/src/WWT.Caching/AppInsightsDistributedCache.cs
+++ b/src/WWT.Caching/AppInsightsDistributedCache.cs
@@ -34,7 +34,7 @@ namespace WWT
           => CreateOperationInternal(key, () => new ValueTask<byte[]>(_other.Get(key))).GetAwaiter().GetResult();
 
         public Task<byte[]> GetAsync(string key, CancellationToken token = default)
-          => CreateOperationInternal(key, async () => await _other.GetAsync(key, default)).AsTask();
+          => CreateOperationInternal(key, async () => await _other.GetAsync(key, token)).AsTask();
 
         public void Refresh(string key) => throw new System.NotImplementedException();
 

--- a/src/WWT.Providers/Providers/Dssprovider.cs
+++ b/src/WWT.Providers/Providers/Dssprovider.cs
@@ -61,7 +61,7 @@ namespace WWT.Providers
 
                 using (var s = await _plateTile.GetStreamAsync(_options.DssTerapixelDir, filename, L5, X5, Y5, token))
                 {
-                    await s.CopyToAsync(context.Response.OutputStream);
+                    await s.CopyToAsync(context.Response.OutputStream, token);
                     context.Response.Flush();
                     context.Response.End();
                 }

--- a/src/WWT.Providers/Providers/Gettileprovider.cs
+++ b/src/WWT.Providers/Providers/Gettileprovider.cs
@@ -36,7 +36,7 @@ namespace WWT.Providers
             }
             else
             {
-                await stream.CopyToAsync(context.Response.OutputStream);
+                await stream.CopyToAsync(context.Response.OutputStream, token);
             }
         }
     }

--- a/src/WWT.Providers/Providers/Martiantileprovider.cs
+++ b/src/WWT.Providers/Providers/Martiantileprovider.cs
@@ -48,7 +48,7 @@ namespace WWT.Providers
                             }
                             else
                             {
-                                await s.CopyToAsync(context.Response.OutputStream);
+                                await s.CopyToAsync(context.Response.OutputStream, token);
                                 context.Response.Flush();
                                 context.Response.End();
                             }
@@ -68,7 +68,7 @@ namespace WWT.Providers
                             }
                             else
                             {
-                                await s.CopyToAsync(context.Response.OutputStream);
+                                await s.CopyToAsync(context.Response.OutputStream, token);
                                 context.Response.Flush();
                                 context.Response.End();
                             }

--- a/src/WWT.Providers/Providers/Tileimageprovider.cs
+++ b/src/WWT.Providers/Providers/Tileimageprovider.cs
@@ -327,6 +327,7 @@ namespace WWT.Providers
                 return path;
             }
 
+            // should be able to give this the cancellationtoken somehow?
             using var stream = await _httpClient.GetStreamAsync(url).ConfigureAwait(false);
 
             using (var fs = File.OpenWrite(path))

--- a/src/WWT.Providers/Providers/Veblendprovider.cs
+++ b/src/WWT.Providers/Providers/Veblendprovider.cs
@@ -83,7 +83,7 @@ namespace WWT.Providers
             else
             {
                 using var veTile = await _veDownloader.DownloadVeTileAsync(VirtualEarthTile.Ortho, level, tileX, tileY, token);
-                await veTile.CopyToAsync(context.Response.OutputStream);
+                await veTile.CopyToAsync(context.Response.OutputStream, token);
             }
         }
     }


### PR DESCRIPTION
My understanding is that you should always propagate the token if possible. Fixing this may fix occasional TaskCancelledExceptions that we see in the App Insights, including in the workhorse DSS provider.