### PR TITLE
Avoid APIs unimplemented in ASP.Net Core

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,14 +224,8 @@ stages:
     # This job deploys the new Docker image to Docker Hub under the `latest`
     # tag, which will then trigger an update of the "stage" deployment slot of
     # the Linux core data app service. To bring the new image into production,
-    # first update the `production` tag on Docker:
-    #
-    #   $ docker pull aasworldwidetelescope/core-data:latest
-    #   $ docker tag aasworldwidetelescope/core-data:latest aasworldwidetelescope/core-data:production
-    #   $ docker push aasworldwidetelescope/core-data:production
-    #
-    # Then "swap" the stage and main slots in the Azure UI after warming up the
-    # new app and doing any final testing.
+    # the stage and main slots should be "swapped" in the Azure UI, after
+    # warming up the new app and doing any final testing.
 
     - job: DockerImage
       pool:

--- a/src/WWT.Providers/IRequest.cs
+++ b/src/WWT.Providers/IRequest.cs
@@ -19,8 +19,6 @@ namespace WWT.Providers
 
         string UserAgent { get; }
 
-        string PhysicalPath { get; }
-
         Stream InputStream { get; }
     }
 }

--- a/src/WWT.Providers/IResponse.cs
+++ b/src/WWT.Providers/IResponse.cs
@@ -16,8 +16,6 @@ namespace WWT.Providers
 
         void AddHeader(string name, string value);
 
-        void WriteFile(string path);
-
         int StatusCode { get; set; }
 
         Task WriteAsync(string message, CancellationToken token);

--- a/src/WWT.Providers/IResponse.cs
+++ b/src/WWT.Providers/IResponse.cs
@@ -18,8 +18,6 @@ namespace WWT.Providers
 
         void WriteFile(string path);
 
-        string Status { get; set; }
-
         int StatusCode { get; set; }
 
         Task WriteAsync(string message, CancellationToken token);

--- a/src/WWT.Providers/IResponse.cs
+++ b/src/WWT.Providers/IResponse.cs
@@ -29,7 +29,5 @@ namespace WWT.Providers
         void ClearHeaders();
 
         void Redirect(string redirectUri);
-
-        string CacheControl { get; set; }
     }
 }

--- a/src/WWT.Providers/IResponse.cs
+++ b/src/WWT.Providers/IResponse.cs
@@ -32,8 +32,6 @@ namespace WWT.Providers
 
         void Redirect(string redirectUri);
 
-        int Expires { get; set; }
-
         string CacheControl { get; set; }
     }
 }

--- a/src/WWT.Providers/IWwtContext.cs
+++ b/src/WWT.Providers/IWwtContext.cs
@@ -11,7 +11,5 @@ namespace WWT.Providers
         IResponse Response { get; }
 
         string MachineName { get; }
-
-        string MapPath(params string[] path);
     }
 }

--- a/src/WWT.Providers/Providers/Catalogprovider.cs
+++ b/src/WWT.Providers/Providers/Catalogprovider.cs
@@ -93,7 +93,7 @@ namespace WWT.Providers
             }
             else
             {
-                context.Response.Status = "304 Not Modified";
+                await Report304Async(context, token);
             }
 
             return true;

--- a/src/WWT.Providers/Providers/Dembathprovider.cs
+++ b/src/WWT.Providers/Providers/Dembathprovider.cs
@@ -14,24 +14,13 @@ namespace WWT.Providers
 
         public override Task RunAsync(IWwtContext context, CancellationToken token)
         {
-            string query = context.Request.Params["Q"];
-            string[] values = query.Split(',');
-            int level = Convert.ToInt32(values[0]);
-            int tileX = Convert.ToInt32(values[1]);
-            int tileY = Convert.ToInt32(values[2]);
-
-            string filename = $@"D:\DEM\bath\{level}\{tileX}\L{level}X{tileX}Y{tileY}.dem";
-
-            if (!File.Exists(filename))
-            {
-                context.Response.StatusCode = 404;
-            }
-            else
-            {
-                context.Response.WriteFile(filename);
-            }
-
-            return Task.CompletedTask;
+            //string query = context.Request.Params["Q"];
+            //string[] values = query.Split(',');
+            //int level = Convert.ToInt32(values[0]);
+            //int tileX = Convert.ToInt32(values[1]);
+            //int tileY = Convert.ToInt32(values[2]);
+            //string filename = $@"D:\DEM\bath\{level}\{tileX}\L{level}X{tileX}Y{tileY}.dem";
+            return Report404Async(context, "no dembath tile", token);
         }
     }
 }

--- a/src/WWT.Providers/Providers/G360provider.cs
+++ b/src/WWT.Providers/Providers/G360provider.cs
@@ -29,10 +29,6 @@ namespace WWT.Providers
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
 
-            context.Response.AddHeader("Expires", "Thu, 31 Dec 2009 16:00:00 GMT");
-            context.Response.AddHeader("ETag", "155");
-            context.Response.AddHeader("Last-Modified", "Tue, 20 May 2008 22:32:37 GMT");
-
             if (level < 12)
             {
                 context.Response.ContentType = "image/png";

--- a/src/WWT.Providers/Providers/Gettourlistprovider.cs
+++ b/src/WWT.Providers/Providers/Gettourlistprovider.cs
@@ -35,7 +35,7 @@ namespace WWT.Providers
                 }
                 else
                 {
-                    context.Response.Status = "304 Not Modified";
+                    await Report304Async(context, token);
                 }
             }
             context.Response.End();

--- a/src/WWT.Providers/Providers/Gettourproviderbase.cs
+++ b/src/WWT.Providers/Providers/Gettourproviderbase.cs
@@ -23,7 +23,7 @@ namespace WWT.Providers
             {
                 if (stream is null)
                 {
-                    context.Response.Status = "404 Not Found";
+                    await Report404Async(context, $"no record for tour GUID {guid}", token);
                 }
                 else
                 {

--- a/src/WWT.Providers/Providers/Gettoursprovider.cs
+++ b/src/WWT.Providers/Providers/Gettoursprovider.cs
@@ -39,7 +39,7 @@ namespace WWT.Providers
                 }
                 else
                 {
-                    context.Response.Status = "304 Not Modified";
+                    await Report304Async(context, token);
                 }
             }
             context.Response.End();

--- a/src/WWT.Providers/Providers/Hirisedem3provider.cs
+++ b/src/WWT.Providers/Providers/Hirisedem3provider.cs
@@ -20,6 +20,8 @@ namespace WWT.Providers
             _options = options;
         }
 
+        // This content-type isn't correct since this is a DEM provider, but it's
+        // what the server has historically reported.
         public override string ContentType => ContentTypes.Png;
 
         public override async Task RunAsync(IWwtContext context, CancellationToken token)

--- a/src/WWT.Providers/Providers/Hirisedem3provider.cs
+++ b/src/WWT.Providers/Providers/Hirisedem3provider.cs
@@ -20,7 +20,7 @@ namespace WWT.Providers
             _options = options;
         }
 
-        public override string ContentType => ContentTypes.Text;
+        public override string ContentType => ContentTypes.Png;
 
         public override async Task RunAsync(IWwtContext context, CancellationToken token)
         {
@@ -30,30 +30,20 @@ namespace WWT.Providers
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
 
-            string filename = $@"\\wwt-mars\marsroot\dem\Merged4\{level}\{tileX}\DL{level}X{tileX}Y{tileY}.dem";
-
-            if (!File.Exists(filename))
+            using (Stream s = await _plateTiles.GetStreamAsync(_options.WwtTilesDir, "marsToastDem.plate", -1, level, tileX, tileY, token))
             {
-                context.Response.ContentType = "image/png";
-                using (Stream s = await _plateTiles.GetStreamAsync(_options.WwtTilesDir, "marsToastDem.plate", -1, level, tileX, tileY, token))
+                if (s.Length == 0)
                 {
-                    if (s.Length == 0)
-                    {
-                        context.Response.Clear();
-                        context.Response.ContentType = "text/plain";
-                        await context.Response.WriteAsync("No image", token);
-                        context.Response.End();
-                        return;
-                    }
-
+                    context.Response.Clear();
+                    context.Response.ContentType = "text/plain";
+                    await context.Response.WriteAsync("No image", token);
+                } else {
                     await s.CopyToAsync(context.Response.OutputStream, token);
                     context.Response.Flush();
-                    context.Response.End();
-                    return;
                 }
             }
 
-            context.Response.WriteFile(filename);
+            context.Response.End();
         }
     }
 }

--- a/src/WWT.Providers/Providers/Hirisedemprovider.cs
+++ b/src/WWT.Providers/Providers/Hirisedemprovider.cs
@@ -20,6 +20,8 @@ namespace WWT.Providers
             _options = options;
         }
 
+        // This content-type isn't correct since this is a DEM provider, but it's
+        // what the server has historically reported.
         public override string ContentType => ContentTypes.Png;
 
         public override async Task RunAsync(IWwtContext context, CancellationToken token)

--- a/src/WWT.Providers/Providers/Loginprovider.cs
+++ b/src/WWT.Providers/Providers/Loginprovider.cs
@@ -35,8 +35,7 @@ namespace WWT.Providers
                 catalog_file = "wwt2_login_pre_equinox.txt";
             }
 
-            //context.Response.Expires = -1;
-            //context.Response.AddHeader("etag", "1-2-3-4-5");
+            context.Response.AddHeader("Expires", "0");
 
             var catalogEntry = await _catalog.GetCatalogEntryAsync(catalog_file, token);
 

--- a/src/WWT.Providers/Providers/Martiantile2provider.cs
+++ b/src/WWT.Providers/Providers/Martiantile2provider.cs
@@ -30,7 +30,6 @@ namespace WWT.Providers
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
             string dataset = values[3];
-            string id = "nothing";
 
             switch (dataset)
             {
@@ -55,9 +54,7 @@ namespace WWT.Providers
                         }
                     }
                     break;
-                case "mars_terrain_color":
-                    id = "220581050";
-                    break;
+
                 case "mars_hirise":
                     if (level < 19)
                     {
@@ -83,6 +80,7 @@ namespace WWT.Providers
                     }
 
                     break;
+
                 case "mars_moc":
                     if (level < 18)
                     {
@@ -108,36 +106,19 @@ namespace WWT.Providers
                         }
                     }
                     break;
-                case "mars_historic_green":
-                    id = "1194136815";
-                    break;
-                case "mars_historic_schiaparelli":
-                    id = "1113282550";
-                    break;
-                case "mars_historic_lowell":
-                    id = "675790761";
-                    break;
-                case "mars_historic_antoniadi":
-                    id = "1648157275";
-                    break;
-                case "mars_historic_mec1":
-                    id = "2141096698";
-                    break;
 
+                // old cases:
+                // "mars_terrain_color" => id = "220581050";
+                // "mars_historic_green" => id = "1194136815";
+                // "mars_historic_schiaparelli" => id = "1113282550";
+                // "mars_historic_lowell" => id = "675790761";
+                // "mars_historic_antoniadi" => id = "1648157275";
+                // "mars_historic_mec1" => id = "2141096698";
             }
 
-            string filename = $@"{_options.DssToastPng}\wwtcache\mars\{id}\{level}\{tileY}\{tileX}_{tileY}.png";
-
-            if (!File.Exists(filename))
-            {
-                // This used to download from $"http://wwt.nasa.gov/wwt/p/{dataset}/{level}/{tileX}/{tileY}.png"
-                // That URL is no longer available.
-                context.Response.StatusCode = 404;
-            }
-            else
-            {
-                context.Response.WriteFile(filename);
-            }
+            // This used to download from $"http://wwt.nasa.gov/wwt/p/{dataset}/{level}/{tileX}/{tileY}.png"
+            // That URL is no longer available.
+            await Report404Async(context, $"Mars dataset {dataset} unavailable", token);
         }
     }
 }

--- a/src/WWT.Providers/Providers/Tiles2provider.cs
+++ b/src/WWT.Providers/Providers/Tiles2provider.cs
@@ -33,10 +33,6 @@ namespace WWT.Providers
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
 
-            context.Response.AddHeader("Expires", "Thu, 31 Dec 2009 16:00:00 GMT");
-            context.Response.AddHeader("ETag", "155");
-            context.Response.AddHeader("Last-Modified", "Tue, 20 May 2008 22:32:37 GMT");
-
             if (_knownPlateFiles.TryNormalizePlateName(values[3], out var file) && level < 10)
             {
                 context.Response.ContentType = "image/png";

--- a/src/WWT.Providers/Providers/Tilesprovider.cs
+++ b/src/WWT.Providers/Providers/Tilesprovider.cs
@@ -33,10 +33,6 @@ namespace WWT.Providers
             int tileX = Convert.ToInt32(values[1]);
             int tileY = Convert.ToInt32(values[2]);
 
-            context.Response.AddHeader("Expires", "Thu, 31 Dec 2009 16:00:00 GMT");
-            context.Response.AddHeader("ETag", "155");
-            context.Response.AddHeader("Last-Modified", "Tue, 20 May 2008 22:32:37 GMT");
-
             if (_knownPlateFiles.TryNormalizePlateName(values[3], out var file) && level < 8)
             {
                 context.Response.ContentType = "image/png";

--- a/src/WWT.Providers/Providers/Webloginprovider.cs
+++ b/src/WWT.Providers/Providers/Webloginprovider.cs
@@ -14,7 +14,7 @@ namespace WWT.Providers
 
         public override async Task RunAsync(IWwtContext context, CancellationToken token)
         {
-            context.Response.Expires = -1;
+            context.Response.AddHeader("Expires", "0");
             await context.Response.WriteAsync("Key:Authorized", token);
         }
     }

--- a/src/WWT.Providers/RequestProvider.cs
+++ b/src/WWT.Providers/RequestProvider.cs
@@ -33,5 +33,15 @@ namespace WWT.Providers
 
             public const string Zip = "application/zip";
         }
+
+        protected Task Report304Async(IWwtContext context, CancellationToken token) {
+            context.Response.StatusCode = 304;
+            return context.Response.WriteAsync("HTTP/304 Not Modified", token);
+        }
+
+        protected Task Report404Async(IWwtContext context, string detail, CancellationToken token) {
+            context.Response.StatusCode = 404;
+            return context.Response.WriteAsync($"HTTP/404 Not Found\n\n{detail}", token);
+        }
     }
 }

--- a/src/WWT.Web/AspNetCoreWwtContext.cs
+++ b/src/WWT.Web/AspNetCoreWwtContext.cs
@@ -91,7 +91,5 @@ namespace WWT.Web
         Task IResponse.WriteAsync(string message, CancellationToken token) => _ctx.Response.WriteAsync(message, token);
 
         void IResponse.Redirect(string redirectUri) => _ctx.Response.Redirect(redirectUri);
-
-        void IResponse.WriteFile(string path) => throw new NotImplementedException();
     }
 }

--- a/src/WWT.Web/AspNetCoreWwtContext.cs
+++ b/src/WWT.Web/AspNetCoreWwtContext.cs
@@ -46,12 +46,6 @@ namespace WWT.Web
 
         Stream IResponse.OutputStream => _ctx.Response.Body;
 
-        int IResponse.Expires
-        {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
-        }
-
         string IResponse.CacheControl
         {
             get => throw new NotImplementedException();

--- a/src/WWT.Web/AspNetCoreWwtContext.cs
+++ b/src/WWT.Web/AspNetCoreWwtContext.cs
@@ -64,8 +64,6 @@ namespace WWT.Web
 
         Stream IRequest.InputStream => _ctx.Request.Body;
 
-        public string MapPath(params string[] path) => throw new NotImplementedException();
-
         void IResponse.AddHeader(string name, string value) => _ctx.Response.Headers.Add(name, value);
 
         void IResponse.Clear()

--- a/src/WWT.Web/AspNetCoreWwtContext.cs
+++ b/src/WWT.Web/AspNetCoreWwtContext.cs
@@ -38,12 +38,6 @@ namespace WWT.Web
             set => _ctx.Response.ContentType = value;
         }
 
-        string IResponse.Status
-        {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
-        }
-
         int IResponse.StatusCode
         {
             get => _ctx.Response.StatusCode;

--- a/src/WWT.Web/AspNetCoreWwtContext.cs
+++ b/src/WWT.Web/AspNetCoreWwtContext.cs
@@ -62,8 +62,6 @@ namespace WWT.Web
 
         string IRequest.UserAgent => _ctx.Request.Headers["User-Agent"];
 
-        string IRequest.PhysicalPath => throw new NotImplementedException();
-
         Stream IRequest.InputStream => _ctx.Request.Body;
 
         public string MapPath(params string[] path) => throw new NotImplementedException();

--- a/src/WWT.Web/AspNetCoreWwtContext.cs
+++ b/src/WWT.Web/AspNetCoreWwtContext.cs
@@ -46,12 +46,6 @@ namespace WWT.Web
 
         Stream IResponse.OutputStream => _ctx.Response.Body;
 
-        string IResponse.CacheControl
-        {
-            get => throw new NotImplementedException();
-            set => _ctx.Response.Headers.Add("Cache-Control", value);
-        }
-
         IParameters IRequest.Params => this;
 
         string IRequest.GetParams(string name) => _ctx.Request.Query[name];

--- a/src/WWT.Web/HelloWorldProvider.cs
+++ b/src/WWT.Web/HelloWorldProvider.cs
@@ -12,7 +12,8 @@ namespace WWT.Providers
 
         public override async Task RunAsync(IWwtContext context, CancellationToken token)
         {
-            string assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            var attr = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            string assemblyVersion = attr?.InformationalVersion ?? "0.0.0-unspecified";
             string reply = $"WWT.Web app version {assemblyVersion}\n";
             await context.Response.WriteAsync(reply, token);
         }

--- a/src/WWTMVC5/SystemWebWwtContext.cs
+++ b/src/WWTMVC5/SystemWebWwtContext.cs
@@ -56,8 +56,6 @@ namespace WWTMVC5
 
         string IRequest.UserAgent => _context.Request.UserAgent;
 
-        string IRequest.PhysicalPath => _context.Request.PhysicalPath;
-
         Stream IRequest.InputStream => _context.Request.InputStream;
 
         string IResponse.ContentType

--- a/src/WWTMVC5/SystemWebWwtContext.cs
+++ b/src/WWTMVC5/SystemWebWwtContext.cs
@@ -19,8 +19,6 @@ namespace WWTMVC5
 
         public string MachineName => _context.Server.MachineName;
 
-        public string MapPath(params string[] path) => _context.Server.MapPath(Path.Combine(path));
-
         public IRequest Request => this;
 
         public IResponse Response => this;

--- a/src/WWTMVC5/SystemWebWwtContext.cs
+++ b/src/WWTMVC5/SystemWebWwtContext.cs
@@ -88,7 +88,5 @@ namespace WWTMVC5
             _context.Response.Write(message);
             return Task.CompletedTask;
         }
-
-        void IResponse.WriteFile(string path) => _context.Response.WriteFile(path);
     }
 }

--- a/src/WWTMVC5/SystemWebWwtContext.cs
+++ b/src/WWTMVC5/SystemWebWwtContext.cs
@@ -74,12 +74,6 @@ namespace WWTMVC5
 
         Stream IResponse.OutputStream => _context.Response.OutputStream;
 
-        int IResponse.Expires
-        {
-            get => _context.Response.Expires;
-            set => _context.Response.Expires = value;
-        }
-
         string IResponse.CacheControl
         {
             get => _context.Response.CacheControl;

--- a/src/WWTMVC5/SystemWebWwtContext.cs
+++ b/src/WWTMVC5/SystemWebWwtContext.cs
@@ -66,12 +66,6 @@ namespace WWTMVC5
             set => _context.Response.ContentType = value;
         }
 
-        string IResponse.Status
-        {
-            get => _context.Response.Status;
-            set => _context.Response.Status = value;
-        }
-
         int IResponse.StatusCode
         {
             get => _context.Response.StatusCode;

--- a/src/WWTMVC5/SystemWebWwtContext.cs
+++ b/src/WWTMVC5/SystemWebWwtContext.cs
@@ -70,11 +70,6 @@ namespace WWTMVC5
 
         Stream IResponse.OutputStream => _context.Response.OutputStream;
 
-        string IResponse.CacheControl
-        {
-            get => _context.Response.CacheControl;
-            set => _context.Response.CacheControl = value;
-        }
         void IResponse.AddHeader(string name, string value) => _context.Response.AddHeader(name, value);
         void IResponse.Clear() => _context.Response.Clear();
         void IResponse.ClearHeaders() => _context.Response.ClearHeaders();


### PR DESCRIPTION
We have a couple of corner cases where the Linux servers could potentially error out because some codepaths use APIs that are marked as unimplemented in the AspNetCoreWwtContext. Here we refactor those usages and get rid of the APIs to avoid any accidental usages of them in the future.

(Example error: GetTourThumbnail.aspx with a GUID corresponding to a nonexistent tour.)