### PR TITLE
WWT.Caching: turn a common LogInformation into a LogTrace

### DIFF
--- a/src/WWT.Caching/WwtStreamSerializer.cs
+++ b/src/WWT.Caching/WwtStreamSerializer.cs
@@ -79,7 +79,7 @@ namespace WWT
                 return input;
             }
 
-            _logger.LogInformation("Copying input stream to a buffer to ensure it is done asynchronously");
+            _logger.LogTrace("Copying input stream to a buffer to ensure it is done asynchronously");
 
             using (input)
             {


### PR DESCRIPTION
Should get our App Insights livestream to a good signal-to-noise ratio.