### PR TITLE
WWTMVC5: take 2 of handling old content URLs

### DIFF
--- a/src/WWTMVC5/Controllers/ContentController.cs
+++ b/src/WWTMVC5/Controllers/ContentController.cs
@@ -47,7 +47,6 @@ namespace WWTMVC5.Controllers
         private INotificationService _notificationService;
 
         private ICommunityService _communityService;
-        private string _oldStaticContentBaseUrl;
 
         #endregion Private Variables
 
@@ -64,7 +63,6 @@ namespace WWTMVC5.Controllers
             _contentService = contentService;
             _notificationService = queueService;
             _communityService = communityService;
-            _oldStaticContentBaseUrl = ConfigReader<string>.GetSetting("OldStaticContentBaseUrl");
         }
 
         #endregion Constructor
@@ -422,17 +420,5 @@ namespace WWTMVC5.Controllers
         }
 
         #endregion Action Methods
-
-        // Catch-all route to redirect requests for old static-files content
-        // that was intermixed into this URL prefix. We've uploaded such files
-        // to a blob storage area.
-        [HttpGet]
-        [Route("Content/{*otherStuff}", Order = 999)]
-        public ActionResult CommunityNoneOfTheAbove(string otherStuff)
-        {
-            var redir = new UriBuilder(_oldStaticContentBaseUrl);
-            redir.Path += otherStuff;
-            return Redirect(redir.ToString());
-        }
     }
 }

--- a/src/WWTMVC5/Web.config
+++ b/src/WWTMVC5/Web.config
@@ -50,35 +50,50 @@
 
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false"/>
+
     <staticContent>
       <mimeMap fileExtension=".wwtl" mimeType="application/wwtl"/>
       <mimeMap fileExtension=".wtt" mimeType="application/wtt"/>
       <mimeMap fileExtension=".wwtmm" mimeType="application/wwtmm"/>
       <mimeMap fileExtension=".wtml" mimeType="application/wtml"/>
-      <!--<mimeMap fileExtension=".msi" mimeType="application/msi" />-->
     </staticContent>
-    <httpErrors errorMode="Custom">
-      <remove statusCode="404"/>
-      <error statusCode="404" path="/Support/Error" responseMode="ExecuteURL"/>
-    </httpErrors>
+
     <httpProtocol>
       <customHeaders>
         <add name="Access-Control-Allow-Origin" value="*"/>
         <add name="Access-Control-Allow-Methods" value="GET,POST,PUT,DELETE"/>
         <add name="Access-Control-Allow-Headers" value="LiveUserToken,Content-Type,Content-Encoding,Content-Disposition"/>
-        <!--Content-Disposition: form-data; name="data"; filename="blob"
-Content-Type: application/x-wt-->
       </customHeaders>
     </httpProtocol>
+
     <security>
       <requestFiltering>
         <requestLimits maxAllowedContentLength="256000000"/>
       </requestFiltering>
     </security>
+
+    <rewrite>
+      <rules>
+        <rule name="communities-oldstatic-1" stopProcessing="true">
+          <match url="^Content/(Images/Planetariums/.*)$" />
+          <action type="Redirect" url="https://web.wwtassets.org/oldcontent/{R:1}" redirectType="Permanent" />
+        </rule>
+        <rule name="communities-oldstatic-2" stopProcessing="true">
+          <match url="^Content/(OpenWWT/.*)$" />
+          <action type="Redirect" url="https://web.wwtassets.org/oldcontent/{R:1}" redirectType="Permanent" />
+        </rule>
+        <rule name="communities-oldstatic-3" stopProcessing="true">
+          <match url="^Content/(Planetariums/.*)$" />
+          <action type="Redirect" url="https://web.wwtassets.org/oldcontent/{R:1}" redirectType="Permanent" />
+        </rule>
+      </rules>
+    </rewrite>
+
     <handlers>
       <add name="wwtweb" verb="*" path="wwtweb/*" type="WWTMVC5.WwtWebHttpHandler, WWTMVC5" preCondition="managedHandler"/>
       <add name="v2" verb="*" path="v2/*" type="WWTMVC5.WwtWebHttpHandler, WWTMVC5" preCondition="managedHandler"/>
     </handlers>
+
     <modules runAllManagedModulesForAllRequests="false">
       <remove name="TelemetryCorrelationHttpModule"/>
       <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="managedHandler"/>
@@ -113,7 +128,6 @@ Content-Type: application/x-wt-->
     <add key="LiveClientSecret" value=""/>
     <add key="LiveClientRedirectUrlMap" value=""/>
     <add key="ExternalUrlMap" value=""/>
-    <add key="OldStaticContentBaseUrl" value=""/>
     <add key="WWTWebBlobs" value=""/>
     <add key="EarthOnlineEntities" value=""/>
     <add key="PrimaryContainer" value="contentcontainer"/>


### PR DESCRIPTION
Based on my research it seems that URL paths with filename extensions don't even get passed to the server code in most cases, or at least not in a way where can intercept some requests but not other requests for static files. IIS is so bad!

For take 2, try hardcoding some manual rewrite rules in the web.config. It is dumb and bad but it seems like the most tractable option.