### PR TITLE
Do not return null for a Task

### DIFF
--- a/src/WWT.Caching/WWT.Caching.csproj
+++ b/src/WWT.Caching/WWT.Caching.csproj
@@ -12,12 +12,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.16.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="Scrutor" Version="3.3.0" />
-    <PackageReference Include="Swick.Cache" Version="0.4.2" />
+    <PackageReference Include="Swick.Cache" Version="0.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/WWT.Providers/Services/IOctTileMapBuilder.cs
+++ b/src/WWT.Providers/Services/IOctTileMapBuilder.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,6 +6,6 @@ namespace WWT.Providers
 {
     public interface IOctTileMapBuilder
     {
-        Task<Stream> GetOctTileAsync(int level, int tileX, int tileY, bool enforceBoundary = false, CancellationToken token = default);
+        Task<Stream?> GetOctTileAsync(int level, int tileX, int tileY, bool enforceBoundary = false, CancellationToken token = default);
     }
 }

--- a/src/WWT.Providers/Services/OctTileMapBuilder.cs
+++ b/src/WWT.Providers/Services/OctTileMapBuilder.cs
@@ -1,4 +1,3 @@
-#nullable disable
 
 using System;
 using System.Drawing;
@@ -13,7 +12,7 @@ namespace WWT.Providers
 {
     public class OctTileMapBuilder : IOctTileMapBuilder
     {
-        public Task<Stream> GetOctTileAsync(int level, int tileX, int tileY, bool enforceBoundary, CancellationToken token)
+        public Task<Stream?> GetOctTileAsync(int level, int tileX, int tileY, bool enforceBoundary, CancellationToken token)
         {
             var map = new OctTileMap(level, tileX, tileY);
 
@@ -24,7 +23,7 @@ namespace WWT.Providers
             {
                 if (map.raMin > 270 | map.decMax < -3 | map.raMax < 105 | map.decMin > 75)
                 {
-                    return null;
+                    return Task.FromResult<Stream?>(null);
                 }
             }
 
@@ -70,7 +69,7 @@ namespace WWT.Providers
 
             var result = bmpOutput.SaveToStream(ImageFormat.Png);
 
-            return Task.FromResult(result);
+            return Task.FromResult<Stream?>(result);
         }
     }
 }


### PR DESCRIPTION
When a method is not marked as async, it has to construct a Task itself. If a null is returned, a NullReferenceException will be thrown when awaited.

This change enables nullable reference checks for the affected files, which would have caught this issue.

This also updates the caching to one that will detect this issue and notify you that it cannot await a null Task.

Fixes #275 