### PR TITLE
Update StackExchange.Redis version

### DIFF
--- a/src/WWT.Caching/WWT.Caching.csproj
+++ b/src/WWT.Caching/WWT.Caching.csproj
@@ -17,6 +17,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="Scrutor" Version="3.3.0" />
+	<!-- This must be referenced separately from the Microsoft.Extensions.Caching.StackExchangeRedis as that will pull in an older version
+	     that can have issues with connection retries. -->
+	<PackageReference Include="StackExchange.Redis" Version="2.2.4" />
     <PackageReference Include="Swick.Cache" Version="0.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
The version brought in by Microsoft.Extensions.Caching.StackExchnageRedis is almost two years old. Recent versions appear to have addressed issues related to connection retries similar to what we've seen in production. By referencing it explicitly, we will opt into this version rather than the version transitively brought in by the MS caching layer.