### PR TITLE
Add login endpoint for new WWT release

### DIFF
--- a/src/WWT.Providers/OtherProviders/Login6Provider.cs
+++ b/src/WWT.Providers/OtherProviders/Login6Provider.cs
@@ -1,0 +1,51 @@
+#nullable disable
+
+using Microsoft.Extensions.Logging;
+using System.Threading;
+using System.Threading.Tasks;
+
+using WWT.Catalog;
+using WWT.PlateFiles;
+
+namespace WWT.Providers
+{
+    [RequestEndpoint("/wwtweb/login6.aspx")]
+    public class Login6Provider : LoginUser
+    {
+        private readonly ICatalogAccessor _catalog;
+        private readonly ILogger<CatalogProvider> _logger;
+
+        public override string ContentType => ContentTypes.Text;
+
+        public override bool IsCacheable => false;
+
+        public Login6Provider(ICatalogAccessor catalogAccessor, ILogger<CatalogProvider> logger)
+        {
+            _catalog = catalogAccessor;
+            _logger = logger;
+        }
+
+        public override async Task RunAsync(IWwtContext context, CancellationToken token)
+        {
+            var catalog_file = "wwt6_login.txt";
+
+            context.Response.AddHeader("Expires", "0");
+
+            var catalogEntry = await _catalog.GetCatalogEntryAsync(catalog_file, token);
+
+            if (catalogEntry is null)
+            {
+                _logger.LogError(string.Format("wwt6::{0} file missing from backing storage", catalog_file));
+                context.Response.StatusCode = 500;
+                return;
+            }
+
+            using (var c = catalogEntry.Contents)
+            {
+                await c.CopyToAsync(context.Response.OutputStream, token);
+                context.Response.Flush();
+                context.Response.End();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new endpoint for login for the new WWT release: `wwtweb/login6.aspx`. These requests are handled by the `Login6Provider` class. The endpoint returns the contents of `wwt6_login.txt`.

The current login endpoint contains some handling for an `Equinox` parameter. Since this endpoint should only be handling the upcoming (and future) versions of the client, this special handling would be vestigial and so I've removed it.