### PR TITLE
src/WWTMVC5/Views/Shared/_Layout.cshtml: migrate Google Analytics tag to GA4

### DIFF
--- a/src/WWTMVC5/Views/Shared/_Layout.cshtml
+++ b/src/WWTMVC5/Views/Shared/_Layout.cshtml
@@ -54,13 +54,13 @@
 			}
 		</style>
 
-		<!-- Global Site Tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-107473046-1"></script>
+		<!-- Global tag (gtag.js) -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-YWNE29K5CB"></script>
 		<script>
 			window.dataLayer = window.dataLayer || [];
-			function gtag() { dataLayer.push(arguments) };
+			function gtag() { dataLayer.push(arguments); }
 			gtag('js', new Date());
-			gtag('config', 'UA-107473046-1');
+			gtag('config', 'G-YWNE29K5CB');
 		</script>
 
 		@RenderSection("head", required: false)


### PR DESCRIPTION
More Google Analytics 4 migration. See also:

- https://github.com/WorldWideTelescope/wwt-web-client/pull/360
- https://github.com/WorldWideTelescope/wwt-user-website/pull/31
- https://github.com/WorldWideTelescope/worldwidetelescope.github.io/pull/86
- https://github.com/WorldWideTelescope/worldwide-telescope-docs-hub/pull/2