### PR TITLE
Use IHttpClientFactory for downstream calls

### DIFF
--- a/src/WWT.Providers/OtherProviders/TileImageProvider.cs
+++ b/src/WWT.Providers/OtherProviders/TileImageProvider.cs
@@ -7,9 +7,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-
 using WWT.Imaging;
-using WWT.PlateFiles;
 
 namespace WWT.Providers
 {
@@ -21,10 +19,10 @@ namespace WWT.Providers
         private readonly ITileAccessor _tileAccessor;
         private readonly string _tempDir;
 
-        public TileImageProvider(IFileNameHasher hasher, ITileAccessor tileAccessor)
+        public TileImageProvider(IFileNameHasher hasher, ITileAccessor tileAccessor, IHttpClientFactory factory)
         {
             _hasher = hasher;
-            _httpClient = new HttpClient();
+            _httpClient = factory.CreateClient();
             _tileAccessor = tileAccessor;
             _tempDir = Path.Combine(Path.GetTempPath(), "wwt_temp");
 
@@ -43,7 +41,6 @@ namespace WWT.Providers
                 {
                     context.Response.ClearHeaders();
                     context.Response.ContentType = "text/plain";
-
                 }
 
                 string url = "";
@@ -329,8 +326,7 @@ namespace WWT.Providers
                 return path;
             }
 
-            // should be able to give this the cancellationtoken somehow?
-            using var stream = await _httpClient.GetStreamAsync(url).ConfigureAwait(false);
+            using var stream = await _httpClient.GetStreamAsync(url, token).ConfigureAwait(false);
 
             using (var fs = File.OpenWrite(path))
             {

--- a/src/WWT.Providers/Services/VirtualEarthDownloader.cs
+++ b/src/WWT.Providers/Services/VirtualEarthDownloader.cs
@@ -15,9 +15,9 @@ namespace WWT.Providers
 
         private readonly HttpClient _httpClient;
 
-        public VirtualEarthDownloader()
+        public VirtualEarthDownloader(IHttpClientFactory factory)
         {
-            _httpClient = new HttpClient();
+            _httpClient = factory.CreateClient();
         }
 
         public int GetServerID(int x, int y)
@@ -111,7 +111,7 @@ namespace WWT.Providers
                 _ => throw new NotImplementedException()
             };
 
-            return _httpClient.GetStreamAsync(url);
+            return _httpClient.GetStreamAsync(url, token);
         }
     }
 }

--- a/src/WWT.Providers/WWT.Providers.csproj
+++ b/src/WWT.Providers/WWT.Providers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>disable</Nullable>
     <NoWarn>$(NoWarn);SYSLIB0014</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" NoWarn="NU1902;NU1903" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/tests/WWT.Tests.props
+++ b/tests/WWT.Tests.props
@@ -2,9 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows'">net6.0;net48</TargetFrameworks>
-    <TargetFramework Condition=" '$(OS)' != 'Windows'">net6.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
A number of the recent errors appear to be from issues connecting to the downstream data providers. This change uses IHttpClientHandler (configured globally for resliency) as well as ensures the cancellation token is passed through.
