### PR TITLE
Set up aspire host to configure redis

### DIFF
--- a/src/WWT.Caching/CachingOptions.cs
+++ b/src/WWT.Caching/CachingOptions.cs
@@ -9,7 +9,5 @@ namespace WWT.Caching
         public bool UseCaching { get; set; }
 
         public TimeSpan SlidingExpiration { get; set; } = TimeSpan.FromMinutes(5);
-
-        public string RedisCacheConnectionString { get; set; }
     }
 }

--- a/src/WWT.Caching/WWT.Caching.csproj
+++ b/src/WWT.Caching/WWT.Caching.csproj
@@ -11,14 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="Scrutor" Version="3.3.0" />
-	<!-- This must be referenced separately from the Microsoft.Extensions.Caching.StackExchangeRedis as that will pull in an older version
-	     that can have issues with connection retries. -->
-	<PackageReference Include="StackExchange.Redis" Version="2.8.16" />
     <PackageReference Include="Swick.Cache" Version="0.5.0" />
   </ItemGroup>
 

--- a/src/WWT.Caching/WwtCachingExtensions.cs
+++ b/src/WWT.Caching/WwtCachingExtensions.cs
@@ -1,8 +1,6 @@
 #nullable disable
 
-using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using Swick.Cache;
 using Swick.Cache.Handlers;
 using System;
@@ -37,18 +35,6 @@ namespace WWT.Caching
                         entry.SlidingExpiration = options.SlidingExpiration;
                     }));
                 });
-
-            if (!string.IsNullOrEmpty(options.RedisCacheConnectionString))
-            {
-                services.AddStackExchangeRedisCache(redisOptions =>
-                {
-                    redisOptions.Configuration = options.RedisCacheConnectionString;
-                });
-            }
-            else
-            {
-                services.AddDistributedMemoryCache();
-            }
 
             return new WwtCacheBuilder(cacheBuilder);
         }

--- a/src/WWT.Web/WWT.Web.csproj
+++ b/src/WWT.Web/WWT.Web.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" Version="8.2.0" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
     <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="8.2.0" />
   </ItemGroup>

--- a/src/WWT.Web/WwtStartupExtensions.cs
+++ b/src/WWT.Web/WwtStartupExtensions.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
-using System;
 using WWT.Azure;
 using WWT.Caching;
 using WWT.Imaging;
@@ -33,9 +32,11 @@ public static class WwtStartupExtensions
         // TODO: change the existing configuration to the new expected pattern
         MergeConfig(configuration, "AzurePlateFileStorageAccount", "WwtFiles");
         MergeConfig(configuration, "MarsStorageAccount", "Mars");
+        MergeConfig(configuration, "RedisConnectionString", "cache");
 
         builder.AddKeyedAzureBlobClient("WwtFiles");
         builder.AddKeyedAzureBlobClient("Mars");
+        builder.AddRedisDistributedCache("cache");
 
         builder.Services
          .AddRequestProviders(options =>
@@ -75,8 +76,6 @@ public static class WwtStartupExtensions
             .AddCaching(options =>
             {
                 configuration.Bind(options);
-                options.RedisCacheConnectionString = configuration["RedisConnectionString"];
-                options.SlidingExpiration = TimeSpan.Parse(configuration["SlidingExpiration"]);
             })
             .CacheType<IMandelbrot>(m => m.Add(nameof(IMandelbrot.CreateMandelbrot)))
             .CacheType<IVirtualEarthDownloader>(plates => plates.Add(nameof(IVirtualEarthDownloader.DownloadVeTileAsync)))

--- a/src/WWT.Web/appsettings.json
+++ b/src/WWT.Web/appsettings.json
@@ -27,7 +27,7 @@
   "TourContainer": "coretours",
   "ImagesTilerContainer": "imagestiler",
   "RedisConnectionString": "",
-  "UseCaching": "false",
+  "UseCaching": "true",
   "SlidingExpiration": "1.00:00:00",
   "APPINSIGHTS_INSTRUMENTATIONKEY": ""
 }

--- a/src/WWT/WWT.AppHost/Program.cs
+++ b/src/WWT/WWT.AppHost/Program.cs
@@ -2,6 +2,9 @@ using Projects;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+var redis = builder.AddRedis("cache")
+    .WithRedisCommander();
+
 var storage = builder.AddAzureStorage("wwtstorage")
     .RunAsEmulator(builder => builder.WithImageTag("3.32.0"));
 
@@ -10,6 +13,7 @@ var mars = storage.AddBlobs("Mars");
 
 builder.AddProject<WWT_Web>("web")
     .WithReference(wwtFiles)
-    .WithReference(mars);
+    .WithReference(mars)
+    .WithReference(redis);
 
 builder.Build().Run();

--- a/src/WWT/WWT.AppHost/WWT.AppHost.csproj
+++ b/src/WWT/WWT.AppHost/WWT.AppHost.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.0" />
     <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="8.2.0" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="8.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change moves the redis configuration to be done via service discovery and aspire. This allows for simpler testing developer side of the effect of caching.
