### PR TITLE
Use a const for activity source key

### DIFF
--- a/src/WWT.Providers/Constants.cs
+++ b/src/WWT.Providers/Constants.cs
@@ -1,0 +1,6 @@
+﻿namespace WWT.Providers;
+
+internal static class Constants
+{
+    public const string ActivitySourceName = "WWT";
+}

--- a/src/WWT.Providers/OtherProviders/Starchart.Aspx.cs
+++ b/src/WWT.Providers/OtherProviders/Starchart.Aspx.cs
@@ -17,7 +17,7 @@ namespace WWT.Providers
         private readonly double[] stars;
         private readonly double[] figures;
 
-        public StarChart([FromKeyedServices("WTT")]ActivitySource activitySource)
+        public StarChart([FromKeyedServices(Constants.ActivitySourceName)]ActivitySource activitySource)
         {
             _activitySource = activitySource;
 

--- a/src/WWT.Providers/OtherProviders/TileImageProvider.cs
+++ b/src/WWT.Providers/OtherProviders/TileImageProvider.cs
@@ -26,7 +26,7 @@ namespace WWT.Providers
         private readonly ITileAccessor _tileAccessor;
         private readonly string _tempDir;
 
-        public TileImageProvider(IFileNameHasher hasher, ITileAccessor tileAccessor, IHttpClientFactory factory, [FromKeyedServices("WTT")] ActivitySource activitySource)
+        public TileImageProvider(IFileNameHasher hasher, ITileAccessor tileAccessor, IHttpClientFactory factory, [FromKeyedServices(Constants.ActivitySourceName)] ActivitySource activitySource)
         {
             _activitySource = activitySource;
             _hasher = hasher;

--- a/src/WWT.Providers/Services/Mandelbrot.cs
+++ b/src/WWT.Providers/Services/Mandelbrot.cs
@@ -3,7 +3,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -16,7 +15,7 @@ namespace WWT.Providers
         private readonly ActivitySource _activitySource;
         private readonly Color[] _colorMap;
 
-        public Mandelbrot([FromKeyedServices("WTT")]ActivitySource activitySource)
+        public Mandelbrot([FromKeyedServices(Constants.ActivitySourceName)]ActivitySource activitySource)
         {
             _activitySource = activitySource;
             _colorMap = CreateColorMap();

--- a/src/WWT.Providers/Services/OctTileMapBuilder.cs
+++ b/src/WWT.Providers/Services/OctTileMapBuilder.cs
@@ -14,7 +14,7 @@ using WWT.Imaging;
 
 namespace WWT.Providers
 {
-    public class OctTileMapBuilder([FromKeyedServices("WTT")] ActivitySource activitySource) : IOctTileMapBuilder
+    public class OctTileMapBuilder([FromKeyedServices(Constants.ActivitySourceName)] ActivitySource activitySource) : IOctTileMapBuilder
     {
         public Task<Stream?> GetOctTileAsync(int level, int tileX, int tileY, bool enforceBoundary, CancellationToken token)
         {

--- a/src/WWT.Providers/TileProviders/BingDEMTileProvider.cs
+++ b/src/WWT.Providers/TileProviders/BingDEMTileProvider.cs
@@ -17,7 +17,7 @@ namespace WWT.Providers
         private readonly IVirtualEarthDownloader _veDownloader;
         private readonly ActivitySource _activitySource;
 
-        public BingDemTileProvider(IVirtualEarthDownloader veDownloader, [FromKeyedServices("WWT")] ActivitySource activitySource)
+        public BingDemTileProvider(IVirtualEarthDownloader veDownloader, [FromKeyedServices(Constants.ActivitySourceName)] ActivitySource activitySource)
         {
             _veDownloader = veDownloader;
             _activitySource = activitySource;

--- a/src/WWT.Providers/TileProviders/MarsHiriseProvider.cs
+++ b/src/WWT.Providers/TileProviders/MarsHiriseProvider.cs
@@ -20,7 +20,7 @@ namespace WWT.Providers
         private readonly IPlateTilePyramid _plateTiles;
         private readonly WwtOptions _options;
 
-        public MarsHiriseProvider(IPlateTilePyramid plateTiles, WwtOptions options, [FromKeyedServices("WTT")]ActivitySource activitySource)
+        public MarsHiriseProvider(IPlateTilePyramid plateTiles, WwtOptions options, [FromKeyedServices(Constants.ActivitySourceName)]ActivitySource activitySource)
         {
             _activitySource = activitySource;
             _plateTiles = plateTiles;

--- a/src/WWT.Providers/TileProviders/MarsMOCProvider.cs
+++ b/src/WWT.Providers/TileProviders/MarsMOCProvider.cs
@@ -19,7 +19,7 @@ namespace WWT.Providers
         private readonly IPlateTilePyramid _plateTiles;
         private readonly WwtOptions _options;
 
-        public MarsMocProvider(IPlateTilePyramid plateTiles, WwtOptions options, [FromKeyedServices("WTT")]ActivitySource activitySource)
+        public MarsMocProvider(IPlateTilePyramid plateTiles, WwtOptions options, [FromKeyedServices(Constants.ActivitySourceName)] ActivitySource activitySource)
         {
             _activitySource = activitySource;
             _plateTiles = plateTiles;
@@ -54,7 +54,7 @@ namespace WWT.Providers
                 if (ll > 8)
                 {
                     int levelDif = ll - 8;
-                    int scale = (int) Math.Pow(2, levelDif);
+                    int scale = (int)Math.Pow(2, levelDif);
                     int tx = xx / scale;
                     int ty = yy / scale;
 
@@ -75,7 +75,7 @@ namespace WWT.Providers
                     using (var stream = await _plateTiles.GetStreamAsync(_options.WwtTilesDir, "marsbasemap.plate", -1, 8, tx, ty, token))
                     using (var bmp1 = Image.Load(stream))
                     {
-                        bmp1.Mutate(x => x.Crop(new Rectangle(offsetX, offsetY, (int) width, (int) height)).Resize(256, 256));
+                        bmp1.Mutate(x => x.Crop(new Rectangle(offsetX, offsetY, (int)width, (int)height)).Resize(256, 256));
                         output.Mutate(x => x.DrawImage(bmp1, 1.0f));
                     }
                 }

--- a/src/WWT.ServiceDefaults/Extensions.cs
+++ b/src/WWT.ServiceDefaults/Extensions.cs
@@ -9,6 +9,7 @@ using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using System.Diagnostics;
+using WWT.Providers;
 
 namespace Microsoft.Extensions.Hosting;
 
@@ -53,7 +54,7 @@ public static class Extensions
                 .AddRuntimeInstrumentation())
             .WithTracing(tracing => tracing
                 .AddAspNetCoreInstrumentation()
-                .AddSource("WWT")
+                .AddSource(Constants.ActivitySourceName)
                 .AddProcessor(new IgnoreFailedBlobProcessor())
                 .AddHttpClientInstrumentation());
 

--- a/src/WWT.ServiceDefaults/WWT.ServiceDefaults.csproj
+++ b/src/WWT.ServiceDefaults/WWT.ServiceDefaults.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\WWT.Providers\Constants.cs" Link="Constants.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.8.0" />

--- a/src/WWT.Web/WWT.Web.csproj
+++ b/src/WWT.Web/WWT.Web.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\WWT.Providers\Constants.cs" Link="Constants.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" Version="8.2.0" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
     <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="8.2.0" />

--- a/src/WWT.Web/WwtCachingExtensions.cs
+++ b/src/WWT.Web/WwtCachingExtensions.cs
@@ -57,7 +57,7 @@ internal static class WwtCachingExtensions
         ObjectPool<StringBuilder> sbPool,
         IOptions<CachingOptions> options,
         IDistributedCache cache,
-        [FromKeyedServices("WWT")] ActivitySource activitySource,
+        [FromKeyedServices(Constants.ActivitySourceName)] ActivitySource activitySource,
         [FromKeyedServices(Original)] ITourAccessor tourAccessor,
         [FromKeyedServices(Original)] IThumbnailAccessor thumbnailAccessor,
         [FromKeyedServices(Original)] IPlateTilePyramid plateTilePyramid,

--- a/src/WWT.Web/WwtStartupExtensions.cs
+++ b/src/WWT.Web/WwtStartupExtensions.cs
@@ -35,7 +35,7 @@ public static class WwtStartupExtensions
         builder.AddKeyedAzureBlobClient("Mars");
         builder.AddRedisDistributedCache("cache");
 
-        builder.Services.AddKeyedSingleton("WWT", new ActivitySource("WWT"));
+        builder.Services.AddKeyedSingleton(Constants.ActivitySourceName, new ActivitySource(Constants.ActivitySourceName));
 
         builder.Services
          .AddRequestProviders(options =>
@@ -108,7 +108,7 @@ public static class WwtStartupExtensions
         {
             // All the providers are registered as singletons, so we can cache them initially
             var provider = (RequestProvider)ActivatorUtilities.CreateInstance(endpoints.ServiceProvider, providerType);
-            endpoints.MapGet(endpoint, (HttpContext ctx, [FromKeyedServices("WWT")] ActivitySource activitySource) =>
+            endpoints.MapGet(endpoint, (HttpContext ctx, [FromKeyedServices(Constants.ActivitySourceName)] ActivitySource activitySource) =>
             {
                 using var activity = activitySource.StartActivity("RequestProvider", ActivityKind.Server);
                 activity?.AddBaggage("ProviderName", providerType.FullName);


### PR DESCRIPTION
Some places referred to it as "WTT" instead of "WWT". Much better to use a const rather than magic strings.