### PR TITLE
Fix refactoring issue in MarsHirise

### DIFF
--- a/src/WWT.Providers/TileProviders/MarsHiriseProvider.cs
+++ b/src/WWT.Providers/TileProviders/MarsHiriseProvider.cs
@@ -1,147 +1,129 @@
-#nullable disable
+#nullable enable
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using System;
 using System.Diagnostics;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using WWT.PlateFiles;
 
-namespace WWT.Providers
+namespace WWT.Providers;
+
+public class MarsHiriseProvider(
+    IPlateTilePyramid plateTiles,
+    WwtOptions options,
+    ILogger<MarsHiriseProvider> logger,
+    [FromKeyedServices(Constants.ActivitySourceName)] ActivitySource activitySource)
 {
-    [RequestEndpoint("/wwtweb/MarsHirise.aspx")]
-    public class MarsHiriseProvider : RequestProvider
+    private const int Width = 256;
+    private const int Height = 256;
+
+    public async Task<Image?> GetImageAsync(int level, int tileX, int tileY, int id, CancellationToken token)
     {
-        private readonly ActivitySource _activitySource;
-        private readonly IPlateTilePyramid _plateTiles;
-        private readonly WwtOptions _options;
-
-        public MarsHiriseProvider(IPlateTilePyramid plateTiles, WwtOptions options, [FromKeyedServices(Constants.ActivitySourceName)]ActivitySource activitySource)
+        if (level > 17)
         {
-            _activitySource = activitySource;
-            _plateTiles = plateTiles;
-            _options = options;
+            return null;
         }
 
-        public override string ContentType => ContentTypes.Png;
+        using var activity = activitySource.StartImageProcessing();
 
-        public override async Task RunAsync(IWwtContext context, CancellationToken token)
+        var image = await GetBaseImage(level, tileX, tileY, token);
+
+        // Apply HiRise overlay if available
+        using var hiRiseOverlay = await LoadHiRiseAsync(level, tileX, tileY, id, token);
+
+        if (hiRiseOverlay is { })
         {
-            const int Width = 256;
-            const int Height = 256;
+            const float Opacity = 0.5f; // This is the opacity of the overlay that will mimic System.Drawing default CompositingMode=SourceOver
 
-            (var errored, var level, var tileX, var tileY, var idText) = await HandleLXYExtraQParameter(context, token);
-            if (errored)
-                return;
-
-            var id = -1;
-
-            if (idText.Length > 0)
+            image.Mutate(c =>
             {
-                try
-                {
-                    id = Convert.ToInt32(idText);
-                }
-                catch
-                {
-                    context.Response.StatusCode = 400;
-                    context.Response.ContentType = ContentTypes.Text;
-                    await context.Response.WriteAsync("HTTP/400 illegal HiRISE \"id\" parameter", token);
-                    return;
-                }
-            }
-
-            if (level > 17)
-            {
-                context.Response.StatusCode = 404;
-                return;
-            }
-
-            using var activity = _activitySource.StartImageProcessing();
-
-            int ll = level;
-            int xx = tileX;
-            int yy = tileY;
-
-            if (ll > 8)
-            {
-                int levelDif = ll - 8;
-                int scale = (int)Math.Pow(2, levelDif);
-                int tx = xx / scale;
-                int ty = yy / scale;
-
-                int offsetX = (xx - (tx * scale)) * (Width / scale);
-                int offsetY = (yy - (ty * scale)) * (Width / scale);
-                float width = Math.Max(2, (Width / scale));
-                float height = width;
-                if ((width + offsetX) >= (Width - 1))
-                {
-                    width -= 1;
-                }
-                if ((height + offsetY) >= (Height - 1))
-                {
-                    height -= 1;
-                }
-
-                using var stream = await _plateTiles.GetStreamAsync(_options.WwtTilesDir, "marsbasemap.plate", -1, 8, tx, ty, token);
-                using var bmpl = Image.Load(stream);
-
-                bmpl.Mutate(c =>
-                {
-                    c.Crop(new Rectangle(offsetX, offsetY, (int)width, (int)height));
-                    c.Resize(Width, Height);
-                });
-
-                await bmpl.RespondPngAsync(context.Response, token);
-            }
-            else
-            {
-                using var stream = await _plateTiles.GetStreamAsync(_options.WwtTilesDir, "marsbasemap.plate", -1, ll, xx, yy, token);
-                using var bmp1 = Image.Load(stream);
-
-                bmp1.Mutate(c =>
-                {
-                    c.Crop(Width, Height);
-                });
-
-                await bmp1.RespondPngAsync(context.Response, token);
-            }
-
-            try
-            {
-                using (var stream = await LoadHiRiseAsync(ll, xx, yy, id, token))
-                {
-                    if (stream != null)
-                    {
-                        using var bmp2 = await Image.LoadAsync(stream, token);
-
-                        bmp2.Mutate(c =>
-                        {
-                            c.Crop(Width, Height);
-                        });
-                        await bmp2.RespondPngAsync(context.Response, token);
-                    }
-                }
-            }
-            catch
-            {
-                using var bmp2 = new Image<Rgba32>(Width, Height);
-                await bmp2.RespondPngAsync(context.Response, token);
-            }
+                c.DrawImage(hiRiseOverlay, Opacity);
+            });
         }
 
-        private Task<Stream> LoadHiRiseAsync(int level, int tileX, int tileY, int id, CancellationToken token)
-        {
-            UInt32 index = ComputeHash(level, tileX, tileY) % 300;
+        return image;
+    }
 
-            return _plateTiles.GetStreamAsync("https://marsstage.blob.core.windows.net/hirise", $"hiriseV5_{index}.plate", id, level, tileX, tileY, token);
+    private async Task<Image> GetBaseImage(int level, int tileX, int tileY, CancellationToken token)
+    {
+        if (level > 8)
+        {
+            int levelDif = level - 8;
+            int scale = (int)Math.Pow(2, levelDif);
+            int tx = tileX / scale;
+            int ty = tileY / scale;
+
+            int offsetX = (tileX - (tx * scale)) * (Width / scale);
+            int offsetY = (tileY - (ty * scale)) * (Width / scale);
+            float width = Math.Max(2, (Width / scale));
+            float height = width;
+            if ((width + offsetX) >= (Width - 1))
+            {
+                width -= 1;
+            }
+            if ((height + offsetY) >= (Height - 1))
+            {
+                height -= 1;
+            }
+
+            using var stream = await plateTiles.GetStreamAsync(options.WwtTilesDir, "marsbasemap.plate", -1, 8, tx, ty, token);
+            var image = await Image.LoadAsync(stream, token);
+
+            image.Mutate(c =>
+            {
+                c.Crop(new Rectangle(offsetX, offsetY, (int)width, (int)height));
+                c.Resize(Width, Height);
+            });
+
+            return image;
+        }
+        else
+        {
+            using var stream = await plateTiles.GetStreamAsync(options.WwtTilesDir, "marsbasemap.plate", -1, level, tileX, tileY, token);
+            var image = await Image.LoadAsync(stream, token);
+
+            image.Mutate(c =>
+            {
+                c.Crop(Width, Height);
+            });
+
+            return image;
+        }
+    }
+
+    private async Task<Image?> LoadHiRiseAsync(int level, int tileX, int tileY, int id, CancellationToken token)
+    {
+        var index = ComputeHash(level, tileX, tileY) % 300;
+
+        try
+        {
+            using var stream = await plateTiles.GetStreamAsync("https://marsstage.blob.core.windows.net/hirise", $"hiriseV5_{index}.plate", id, level, tileX, tileY, token);
+
+            if (stream is null)
+            {
+                return null;
+            }
+
+            var hiRiseOverlay = await Image.LoadAsync(stream, token);
+
+            hiRiseOverlay.Mutate(c =>
+            {
+                c.Crop(Width, Height);
+            });
+
+            return hiRiseOverlay;
+        }
+        catch (Exception e)
+        {
+            logger.LogWarning(e, "Failed to find hirise overlay");
+            return null;
         }
 
-        private UInt32 ComputeHash(int level, int x, int y)
+        static uint ComputeHash(int level, int x, int y)
         {
             return DirectoryEntry.ComputeHash(level + 128, x, y);
         }

--- a/src/WWT.Web/ImageResultExtensions.cs
+++ b/src/WWT.Web/ImageResultExtensions.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IO;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Formats.Png;
+using System.Threading.Tasks;
+
+namespace WWT.Web;
+
+public static class ImageResultExtensions
+{
+    public static ImageResult Png(this IResultExtensions _, Image image) => new(image, "image/png", new PngEncoder());
+
+    public static ImageResult Jpeg(this IResultExtensions _, Image image) => new(image, "image/jpeg", new JpegEncoder());
+}
+
+public sealed class ImageResult(Image image, string contentType, IImageEncoder encoder) : IResult, IStatusCodeHttpResult, IContentTypeHttpResult
+{
+    public int? StatusCode => StatusCodes.Status200OK;
+
+    public string ContentType => contentType;
+
+    public async Task ExecuteAsync(HttpContext httpContext)
+    {
+        var manager = httpContext.RequestServices.GetRequiredService<RecyclableMemoryStreamManager>();
+
+        using var stream = manager.GetStream();
+
+        // Copy to local stream so we can get a Content-Length header
+        await image.SaveAsync(stream, encoder, httpContext.RequestAborted);
+
+        httpContext.Response.ContentType = contentType;
+        httpContext.Response.ContentLength = stream.Length;
+
+        stream.Position = 0;
+
+        await stream.CopyToAsync(httpContext.Response.Body, httpContext.RequestAborted);
+
+        image.Dispose();
+    }
+}

--- a/src/WWT.Web/WWT.Web.csproj
+++ b/src/WWT.Web/WWT.Web.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" Version="8.2.0" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
     <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="8.2.0" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WWT.Web/WwtEndpointExtensions.cs
+++ b/src/WWT.Web/WwtEndpointExtensions.cs
@@ -47,15 +47,25 @@ public static class WwtEndpointExtensions
             return TypedResults.Stream(mandelbrot.CreateMandelbrot(q.Level, q.X, q.Y), "image/jpeg");
         }).WithCacheControl();
 
-        group.MapGet("dss.aspx", static async Task<Results<FileStreamHttpResult, NotFound>> ([FromQuery] LXY q, DSSProvider dss, CancellationToken token) =>
+        group.MapGet("marshirise.aspx", static async Task<Results<ImageResult, NotFound>> ([FromQuery] LXYId q, MarsHiriseProvider marsHirise) =>
         {
-            if (await dss.GetStreamAsync(q.Level, q.X, q.Y, token) is { } stream)
+            if (await marsHirise.GetImageAsync(q.Level, q.X, q.Y, q.Id, CancellationToken.None) is { } image)
             {
-                return TypedResults.Stream(stream, "image/png");
+                return TypedResults.Extensions.Png(image);
             }
 
             return TypedResults.NotFound();
         }).WithCacheControl();
+
+        group.MapGet("dss.aspx", static async Task<Results<FileStreamHttpResult, NotFound>> ([FromQuery] LXY q, DSSProvider dss, CancellationToken token) =>
+            {
+                if (await dss.GetStreamAsync(q.Level, q.X, q.Y, token) is { } stream)
+                {
+                    return TypedResults.Stream(stream, "image/png");
+                }
+
+                return TypedResults.NotFound();
+            }).WithCacheControl();
 
         return group;
     }
@@ -162,7 +172,47 @@ public static class WwtEndpointExtensions
                     int.TryParse(sX, NumberStyles.Integer, provider, out var x) &&
                     int.TryParse(sY, NumberStyles.Integer, provider, out var y))
                 {
-                    result = new LXY(level, x, y);
+                    result = new(level, x, y);
+                    return true;
+                }
+            }
+
+            result = default;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Provides a strongly typed representation of the LXY query parameter often used as the 'Q' parameter. This will be used
+    /// to attempt to parse the parameter, and if it fails, the request will be rejected with an explanation of the failure.
+    /// </summary>
+    private record struct LXYId(int Level, int X, int Y, int Id) : IParsable<LXYId>
+    {
+        public static LXYId Parse(string s, IFormatProvider provider)
+        {
+            if (TryParse(s, provider, out var result))
+            {
+                return result;
+            }
+
+            throw new FormatException("Could not parse input for LXYId");
+        }
+
+        public static bool TryParse([NotNullWhen(true)] string s, IFormatProvider provider, [MaybeNullWhen(false)] out LXYId result)
+        {
+            if (LXY.TryParse(s, provider, out var lxy))
+            {
+                result = new LXYId(lxy.Level, lxy.X, lxy.Y, -1);
+                return true;
+            }
+            else if (s.Split([','], count: 4, StringSplitOptions.TrimEntries) is [{ } sLevel, { } sX, { } sY, { } sId])
+            {
+                if (int.TryParse(sLevel, NumberStyles.Integer, provider, out var level) &&
+                    int.TryParse(sX, NumberStyles.Integer, provider, out var x) &&
+                    int.TryParse(sY, NumberStyles.Integer, provider, out var y) &&
+                    int.TryParse(sId, NumberStyles.Integer, provider, out var id))
+                {
+                    result = new(level, x, y, id);
                     return true;
                 }
             }

--- a/src/WWT.Web/WwtStartupExtensions.cs
+++ b/src/WWT.Web/WwtStartupExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.IO;
 using System.Diagnostics;
 using WWT.Azure;
 using WWT.Providers;
@@ -30,8 +31,10 @@ public static class WwtStartupExtensions
         builder.AddKeyedAzureBlobClient("Mars");
         builder.AddRedisDistributedCache("cache");
 
+        builder.Services.AddSingleton<RecyclableMemoryStreamManager>();
         builder.Services.AddKeyedSingleton(Constants.ActivitySourceName, new ActivitySource(Constants.ActivitySourceName));
         builder.Services.AddSingleton<DSSProvider>();
+        builder.Services.AddSingleton<MarsHiriseProvider>();
 
         builder.Services
          .AddRequestProviders(options =>


### PR DESCRIPTION
When refactoring MarsHirise to use ImageSharp, the overlay wasn't drawn to the image. Instead, the base image was returned before the overlay was applied. This fixes it up to follow the same logic as with System.Drawing.
