### PR TITLE
Use a per-host resiliency pipeline

### DIFF
--- a/src/WWT.ServiceDefaults/Extensions.cs
+++ b/src/WWT.ServiceDefaults/Extensions.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
@@ -29,7 +30,8 @@ public static class Extensions
         builder.Services.ConfigureHttpClientDefaults(http =>
         {
             // Turn on resilience by default
-            http.AddStandardResilienceHandler();
+            http.AddStandardResilienceHandler()
+                .SelectPipelineByAuthority();
 
             // Turn on service discovery by default
             http.AddServiceDiscovery();


### PR DESCRIPTION
This will ensure things like retries/circuit breakers only affect a specific host. For example, calling one downstream API that starts failing won't cause the others to start failing.
