### PR TITLE
Use SkyServer for SDSS12

### DIFF
--- a/src/WWT.Providers/Services/OctTileMapBuilder.cs
+++ b/src/WWT.Providers/Services/OctTileMapBuilder.cs
@@ -60,11 +60,15 @@ public class OctTileMapBuilder([FromKeyedServices(Constants.ActivitySourceName)]
 
     private async Task<SdssImage?> LoadImage(double raLeft, double decTop, double raRight, double decBottom, bool dr12, CancellationToken token)
     {
-        var innerPath = dr12 ? "DR12" : "dr6";
+        var innerPath = dr12 ? "dr12" : "dr6";
         var raCenter = (raLeft + raRight) / 2.0;
         var decCenter = (decBottom + decTop) / 2.0;
         var scale = Math.Abs(decBottom - decTop) / 500.0;
-        var address = $"https://skyservice.pha.jhu.edu/{innerPath}/imgcutout/getjpeg.aspx?ra={raCenter}&dec={decCenter}&scale={scale * 3600.0}&width={512.0}&height={512.0}&opt=&query=";
+        var updatedScale = scale * 3600.0;
+        var address = dr12 ?
+        $"https://skyserver.sdss.org/{innerPath}/SkyServerWS/ImgCutout/getjpeg?TaskName=SkyServer.Chart.List&ra={raCenter}&dec={decCenter}&scale={updatedScale}&width={512.0}&height={512.0}&opt="
+        :
+        $"https://skyservice.pha.jhu.edu/{innerPath}/imgcutout/getjpeg.aspx?ra={raCenter}&dec={decCenter}&scale={updatedScale}&width={512.0}&height={512.0}&opt=&query=";
 
         using var client = httpClientFactory.CreateClient();
         using var response = await client.GetAsync(address, token);

--- a/src/WWT.Providers/Services/OctTileMapBuilder.cs
+++ b/src/WWT.Providers/Services/OctTileMapBuilder.cs
@@ -63,12 +63,11 @@ public class OctTileMapBuilder([FromKeyedServices(Constants.ActivitySourceName)]
         var innerPath = dr12 ? "dr12" : "dr6";
         var raCenter = (raLeft + raRight) / 2.0;
         var decCenter = (decBottom + decTop) / 2.0;
-        var scale = Math.Abs(decBottom - decTop) / 500.0;
-        var updatedScale = scale * 3600.0;
+        var scale = Math.Abs(decBottom - decTop) * 3600.0 / 500.0;
         var address = dr12 ?
-        $"https://skyserver.sdss.org/{innerPath}/SkyServerWS/ImgCutout/getjpeg?TaskName=SkyServer.Chart.List&ra={raCenter}&dec={decCenter}&scale={updatedScale}&width={512.0}&height={512.0}&opt="
+        $"https://skyserver.sdss.org/{innerPath}/SkyServerWS/ImgCutout/getjpeg?TaskName=SkyServer.Chart.List&ra={raCenter}&dec={decCenter}&scale={scale}&width={512.0}&height={512.0}&opt="
         :
-        $"https://skyservice.pha.jhu.edu/{innerPath}/imgcutout/getjpeg.aspx?ra={raCenter}&dec={decCenter}&scale={updatedScale}&width={512.0}&height={512.0}&opt=&query=";
+        $"https://skyservice.pha.jhu.edu/{innerPath}/imgcutout/getjpeg.aspx?ra={raCenter}&dec={decCenter}&scale={scale}&width={512.0}&height={512.0}&opt=&query=";
 
         using var client = httpClientFactory.CreateClient();
         using var response = await client.GetAsync(address, token);


### PR DESCRIPTION
This PR updates the SDSS12 endpoint to use the SkyServer service, rather than the JHU one, for fetching deeper tiles (for lower levels on the tile map, we use a plate file). The images are the same (I did some spot-checking at different sky locations and used image comparison on the corresponding images and found no differences), and we've seen some reliability issues with the JHU server.

The motivation for this is https://github.com/cosmicds/hubbleds/issues/644.