### PR TITLE
Fix issue with SDSS image scale

### DIFF
--- a/src/WWT.Providers/Services/OctTileMapBuilder.cs
+++ b/src/WWT.Providers/Services/OctTileMapBuilder.cs
@@ -63,11 +63,12 @@ public class OctTileMapBuilder([FromKeyedServices(Constants.ActivitySourceName)]
         var innerPath = dr12 ? "dr12" : "dr6";
         var raCenter = (raLeft + raRight) / 2.0;
         var decCenter = (decBottom + decTop) / 2.0;
-        var scale = Math.Abs(decBottom - decTop) * 3600.0 / 500.0;
+        var scale = Math.Abs(decBottom - decTop) / 500.0;
+        var requestScale = scale * 3600.0;
         var address = dr12 ?
-        $"https://skyserver.sdss.org/{innerPath}/SkyServerWS/ImgCutout/getjpeg?TaskName=SkyServer.Chart.List&ra={raCenter}&dec={decCenter}&scale={scale}&width={512.0}&height={512.0}&opt="
+        $"https://skyserver.sdss.org/{innerPath}/SkyServerWS/ImgCutout/getjpeg?TaskName=SkyServer.Chart.List&ra={raCenter}&dec={decCenter}&scale={requestScale}&width={512.0}&height={512.0}&opt="
         :
-        $"https://skyservice.pha.jhu.edu/{innerPath}/imgcutout/getjpeg.aspx?ra={raCenter}&dec={decCenter}&scale={scale}&width={512.0}&height={512.0}&opt=&query=";
+        $"https://skyservice.pha.jhu.edu/{innerPath}/imgcutout/getjpeg.aspx?ra={raCenter}&dec={decCenter}&scale={requestScale}&width={512.0}&height={512.0}&opt=&query=";
 
         using var client = httpClientFactory.CreateClient();
         using var response = await client.GetAsync(address, token);


### PR DESCRIPTION
The readability fix that we made on https://github.com/WorldWideTelescope/wwt-website/pull/336 ended up breaking the SDSS tiles on staging because we actually do use the original scale value later on. This PR corrects the issue.