### PR TITLE
Remove WebRequest usage

### DIFF
--- a/src/WWT.Imaging/WWT.Imaging.csproj
+++ b/src/WWT.Imaging/WWT.Imaging.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <NoWarn>$(NoWarn);SYSLIB0014</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WWT.Providers/OtherProviders/IssTleProvider.cs
+++ b/src/WWT.Providers/OtherProviders/IssTleProvider.cs
@@ -1,12 +1,12 @@
 using System;
-using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace WWT.Providers
 {
     [RequestEndpoint("/wwtweb/isstle.aspx")]
-    public class IsstleProvider : RequestProvider
+    public class IsstleProvider(IHttpClientFactory factory) : RequestProvider
     {
         public override string ContentType => ContentTypes.Text;
 
@@ -30,10 +30,10 @@ namespace WWT.Providers
 
                 if (String.IsNullOrEmpty(reply) || ts.TotalDays > .5 || context.Request.Params["refresh"] != null)
                 {
-                    using (WebClient wc = new WebClient())
+                    using (var client = factory.CreateClient())
                     {
-                        string data = wc.DownloadString(theUrl);
-                        string[] lines = data.Split(new char[] { '\n', '\r' });
+                        string data = await client.GetStringAsync(theUrl, token);
+                        string[] lines = data.Split(['\n', '\r']);
 
                         string line1 = "";
                         string line2 = "";

--- a/src/WWT.Providers/WWT.Providers.csproj
+++ b/src/WWT.Providers/WWT.Providers.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>disable</Nullable>
-    <NoWarn>$(NoWarn);SYSLIB0014</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 


### PR DESCRIPTION
This API is deprecated and had been part of the migration to netcore but was missed because the warning for it has been disabled. This removes the warning and switches to the more modern IHttpClientFactory to take advantage of telemetry/caching/etc.
