### PR TITLE
Don't serve HiRISE data

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -29,6 +29,7 @@ deprecated. We log them here.
 | `/wwtweb/jupiter.aspx` | Unused, broken | [#258](https://github.com/WorldWideTelescope/wwt-website/pull/258) |
 | `/wwtweb/mandel1.aspx` | Unused, broken | [#258](https://github.com/WorldWideTelescope/wwt-website/pull/258) |
 | `/wwtweb/mars.aspx` | Unused, broken | [#258](https://github.com/WorldWideTelescope/wwt-website/pull/258) |
+| `/wwtweb/marshirise.aspx` | Low usage, removed to reduce costs | [#258](https://github.com/WorldWideTelescope/wwt-website/pull/258) |
 | `/wwtweb/martiantileempty.aspx` | Data is from `wwt.nasa.gov` which is no longer available. | [#182](https://github.com/WorldWideTelescope/wwt-website/pull/182) |
 | `/wwtweb/martiantile2.aspx` | Unused, broken | [#258](https://github.com/WorldWideTelescope/wwt-website/pull/258) |
 | `/wwtweb/moondem.aspx` | Unused, broken | [#258](https://github.com/WorldWideTelescope/wwt-website/pull/258) |

--- a/src/WWT.Web/WwtEndpointExtensions.cs
+++ b/src/WWT.Web/WwtEndpointExtensions.cs
@@ -47,16 +47,6 @@ public static class WwtEndpointExtensions
             return TypedResults.Stream(mandelbrot.CreateMandelbrot(q.Level, q.X, q.Y), "image/jpeg");
         }).WithCacheControl();
 
-        group.MapGet("marshirise.aspx", static async Task<Results<ImageResult, NotFound>> ([FromQuery] LXYId q, MarsHiriseProvider marsHirise) =>
-        {
-            if (await marsHirise.GetImageAsync(q.Level, q.X, q.Y, q.Id, CancellationToken.None) is { } image)
-            {
-                return TypedResults.Extensions.Png(image);
-            }
-
-            return TypedResults.NotFound();
-        }).WithCacheControl();
-
         group.MapGet("sdsstoast.aspx", static async Task<Results<FileStreamHttpResult, NotFound>> ([FromQuery] LXY q, SDSSToastProvider sdss, CancellationToken token) =>
         {
             if (await sdss.GetStreamAsync(q.Level, q.X, q.Y, token) is { } stream)
@@ -100,6 +90,7 @@ public static class WwtEndpointExtensions
         deprecated.MapGet("/jupiter.aspx", DeprecatedMessaging);
         deprecated.MapGet("/mandel1.aspx", DeprecatedMessaging);
         deprecated.MapGet("/mars.aspx", DeprecatedMessaging);
+        deprecated.MapGet("/marshirise.aspx", DeprecatedMessaging);
         deprecated.MapGet("/MartianTile2.aspx", DeprecatedMessaging);
         deprecated.MapGet("/moondem.aspx", DeprecatedMessaging);
         deprecated.MapGet("/moonOct.aspx", DeprecatedMessaging);


### PR DESCRIPTION
For storage cost reasons we've moved the Mars HiRISE data into cold storage, and we don't really want anyone freely accessing it as it's now easy to run up a big access bill. This PR updates the relevant endpoint to now return a 410 (Gone) status.