### PR TITLE
Bump OpenTelemetry and ImageSharp versions

### DIFF
--- a/src/WWT.Imaging/WWT.Imaging.csproj
+++ b/src/WWT.Imaging/WWT.Imaging.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.4" />
   </ItemGroup>
 

--- a/src/WWT.ServiceDefaults/WWT.ServiceDefaults.csproj
+++ b/src/WWT.ServiceDefaults/WWT.ServiceDefaults.csproj
@@ -16,11 +16,11 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR bumps our versions of OpenTelemetry packages to resolve [CVE-2026-42191](https://github.com/advisories/GHSA-4625-4j76-fww9) and the ImageSharp version to fix [CVE-2025-54575](https://github.com/advisories/GHSA-rxmq-m78w-7wmc).